### PR TITLE
Reworked auth flow, facebook integration to user creation process

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.eddierangel.southkern.android">
 
     <uses-permission android:name="android.permission.INTERNET" />
@@ -20,6 +21,27 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".main.UserCreation"/>
+        <!-- Facebook start -->
+        <meta-data
+            tools:replace="android:value"
+            android:name="com.facebook.sdk.ApplicationId"
+            android:value="@string/facebook_app_id"/>
+        <activity android:name="com.facebook.FacebookActivity"
+            android:configChanges=
+                "keyboard|keyboardHidden|screenLayout|screenSize|orientation"
+            android:label="@string/app_name" />
+        <activity
+            android:name="com.facebook.CustomTabActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="@string/fb_login_protocol_scheme" />
+            </intent-filter>
+        </activity>
+        <!-- Facebook end -->
         <activity android:name=".main.MainActivity"
             android:label="@string/select_channel_type"/>
         <activity android:name=".utils.PhotoViewerActivity" />

--- a/app/src/main/java/com/eddierangel/southkern/android/main/LoginActivity.java
+++ b/app/src/main/java/com/eddierangel/southkern/android/main/LoginActivity.java
@@ -1,5 +1,6 @@
 package com.eddierangel.southkern.android.main;
 
+import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -8,10 +9,7 @@ import android.support.design.widget.Snackbar;
 import android.support.design.widget.TextInputEditText;
 import android.support.v4.widget.ContentLoadingProgressBar;
 import android.support.v7.app.AppCompatActivity;
-import android.view.Display;
-import android.view.View;
-import android.widget.Button;
-import android.widget.TextView;
+import android.util.Log;
 import android.widget.Toast;
 
 import com.firebase.ui.auth.AuthUI;
@@ -32,17 +30,18 @@ import com.sendbird.android.User;
 import com.eddierangel.southkern.android.R;
 import com.eddierangel.southkern.android.utils.PreferenceUtils;
 
+import org.json.JSONObject;
+
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 
 public class LoginActivity extends AppCompatActivity {
 
     private CoordinatorLayout mLoginLayout;
-    private TextInputEditText mUserIdConnectEditText, mUserNicknameEditText;
-    private Button mConnectButton;
-    private Button mFirebaseLogoutButton;
+    private HashMap<String, String> userData;
     private ContentLoadingProgressBar mProgressBar;
 
     // Firebase instance variables
@@ -60,7 +59,7 @@ public class LoginActivity extends AppCompatActivity {
      * @param firebaseToken firebase token is required to use endpoint, so only firebase authenticated users can authenticate with sendbird
      * this function returns the sendbird API token that is accessed by using task.getResult();
      * */
-    private Task<String> getSendbirdUserWithToken(String userID, String nickname, String firebaseToken) {
+    private Task<HashMap> getSendbirdUserWithToken(String userID, String nickname, String firebaseToken) {
         // Create the arguments to the callable function.
         Map<String, Object> data = new HashMap<>();
         data.put("userID", userID);
@@ -70,14 +69,13 @@ public class LoginActivity extends AppCompatActivity {
         return mFunctions
                 .getHttpsCallable("getSendbirdUserWithToken")
                 .call(data)
-                .continueWith(new Continuation<HttpsCallableResult, String>() {
+                .continueWith(new Continuation<HttpsCallableResult, HashMap>() {
                     @Override
-                    public String then(@NonNull Task<HttpsCallableResult> task) throws Exception {
+                    public HashMap then(@NonNull Task<HttpsCallableResult> task) throws Exception {
                         // This continuation runs on either success or failure, but if the task
                         // has failed then getResult() will throw an Exception which will be
                         // propagated down.
-                        String result = (String) task.getResult().getData();
-                        return result;
+                        return (HashMap) task.getResult().getData();
                     }
                 });
     }
@@ -94,75 +92,20 @@ public class LoginActivity extends AppCompatActivity {
 
         mLoginLayout = (CoordinatorLayout) findViewById(R.id.layout_login);
 
-        mUserIdConnectEditText = (TextInputEditText) findViewById(R.id.edittext_login_user_id);
-        mUserNicknameEditText = (TextInputEditText) findViewById(R.id.edittext_login_user_nickname);
-
-        mUserIdConnectEditText.setText(PreferenceUtils.getUserId(this));
-        mUserNicknameEditText.setText(PreferenceUtils.getNickname(this));
-
-        mFirebaseLogoutButton = (Button) findViewById(R.id.button_logout_firebase);
-        mFirebaseLogoutButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                logOut();
-            }
-        });
-
-        mConnectButton = (Button) findViewById(R.id.button_login_connect);
-        mConnectButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                // Show the loading indicator
-                showProgressBar(true);
-                mConnectButton.setEnabled(false);
-
-                String userId = mUserIdConnectEditText.getText().toString();
-                // Remove all spaces from userID
-                final String userIdFormatted = userId.replaceAll("\\s", "");
-
-                final String userNickname = mUserNicknameEditText.getText().toString();
-
-                PreferenceUtils.setUserId(LoginActivity.this, userId);
-                PreferenceUtils.setNickname(LoginActivity.this, userNickname);
-                String firebaseToken = PreferenceUtils.getFirebaseToken(LoginActivity.this);
-
-                /* Use firebase functions to issue a sendbird token to the user after authorizing with firebase. */
-                getSendbirdUserWithToken(userIdFormatted, userNickname, firebaseToken)
-                    .addOnCompleteListener(new OnCompleteListener<String>() {
-                        @Override
-                        public void onComplete(@NonNull Task<String> task) {
-                            if (!task.isSuccessful()) {
-                                Exception e = task.getException();
-                                if (e instanceof FirebaseFunctionsException) {
-                                    FirebaseFunctionsException ffe = (FirebaseFunctionsException) e;
-                                    FirebaseFunctionsException.Code code = ffe.getCode();
-                                    Object details = ffe.getDetails();
-                                }
-
-                                // ...
-                            }
-                            // success
-                            // save sendbird token to shared store
-                            PreferenceUtils.setSendbirdToken(LoginActivity.this, task.getResult());
-                            connectToSendBird(userIdFormatted, userNickname, task.getResult());
-                        }
-                    });;
-
-            }
-        });
-
         // A loading indicator
         mProgressBar = (ContentLoadingProgressBar) findViewById(R.id.progress_bar_login);
 
         mAuthStateListener = new FirebaseAuth.AuthStateListener() {
             @Override
             public void onAuthStateChanged(@NonNull FirebaseAuth firebaseAuth) {
-                FirebaseUser user = firebaseAuth.getCurrentUser();
+                final FirebaseUser user = firebaseAuth.getCurrentUser();
                 if (user != null) {
                     // user is signed in
-                    mUserIdConnectEditText.setText(user.getEmail());
-                    mUserNicknameEditText.setText(user.getDisplayName());
+                    PreferenceUtils.setUserId(LoginActivity.this, user.getEmail());
+                    PreferenceUtils.setNickname(LoginActivity.this, "Guest");
 
+                    // Show the loading indicator
+                    showProgressBar(true);
                     // Retrieve firebase token from user.
                     user.getIdToken(true).addOnSuccessListener(new OnSuccessListener<GetTokenResult>() {
                         @Override
@@ -170,6 +113,47 @@ public class LoginActivity extends AppCompatActivity {
                             String idToken = result.getToken();
                             // save token to shared store.
                             PreferenceUtils.setFirebaseToken(LoginActivity.this, idToken);
+
+                            final String userId = user.getEmail();
+
+                            /* Use firebase functions to issue a sendbird token to the user after authorizing with firebase. */
+                            getSendbirdUserWithToken(userId, "Guest", idToken)
+                                    .addOnCompleteListener(new OnCompleteListener<HashMap>() {
+                                        @Override
+                                        public void onComplete(@NonNull Task<HashMap> task) {
+                                            if (!task.isSuccessful()) {
+                                                Exception e = task.getException();
+                                                if (e instanceof FirebaseFunctionsException) {
+                                                    FirebaseFunctionsException ffe = (FirebaseFunctionsException) e;
+                                                    FirebaseFunctionsException.Code code = ffe.getCode();
+                                                    Object details = ffe.getDetails();
+                                                }
+
+                                                // ...
+                                            }
+                                            // success
+                                            // save sendbird token to shared store
+                                            String sendbirdToken;
+                                            try {
+                                                sendbirdToken = (String) task.getResult().get("token");
+                                                Boolean firstLogin = (Boolean) task.getResult().get("firstLogin");
+                                                PreferenceUtils.setSendbirdToken(LoginActivity.this.getApplicationContext(), sendbirdToken);
+                                                if (firstLogin) {
+                                                    // It is the user's first time logging in -> show them UserCreation form
+                                                    Intent intent = new Intent(LoginActivity.this, UserCreation.class);
+                                                    startActivityForResult(intent, 1);
+                                                }
+                                                if (!firstLogin && task.getResult().get("nickname") != null) {
+                                                    // This isn't the user's first rodeo -> connect and show them main feed
+                                                    String userNickname = (String) task.getResult().get("nickname");
+                                                    connectToSendBird(userId, userNickname, sendbirdToken);
+                                                }
+                                            }
+                                            catch(Exception e) {
+                                                Log.i("sendbirdtokenErr", "" + e);
+                                            }
+                                        }
+                                    });;
                         }
                     });
                 } else {
@@ -187,6 +171,22 @@ public class LoginActivity extends AppCompatActivity {
             }
         };
     }
+    // Obtain user and social profile data from UserCreation class and use it to connect to sendbird
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        HashMap<String, String> result;
+            if (requestCode == 1) {
+                if (resultCode == Activity.RESULT_OK) {
+                    String userId = PreferenceUtils.getUserId(LoginActivity.this);
+                    String sendbirdToken = PreferenceUtils.getSendbirdToken(LoginActivity.this);
+                    result = (HashMap<String, String>) data.getSerializableExtra("userData");
+                    userData = result;
+                    connectToSendBird(userId, result.get("user_name"), sendbirdToken);
+                }
+            }
+
+    }
 
     @Override
     protected void onStart() {
@@ -202,7 +202,8 @@ public class LoginActivity extends AppCompatActivity {
      * @param userNickname  The user's nickname, which will be displayed in chats.
      * @param sendbirdToken The user's token that we will use to connect to sendbird securely.
      */
-    private void connectToSendBird(final String userId, final String userNickname, final String sendbirdToken ) {
+    private void connectToSendBird(final String userId, final String userNickname, final String sendbirdToken) {
+
         SendBird.connect(userId, sendbirdToken, new SendBird.ConnectHandler() {
             @Override
             public void onConnected(User user, SendBirdException e) {
@@ -211,6 +212,7 @@ public class LoginActivity extends AppCompatActivity {
 
                 if (e != null) {
                     // Error!
+                    Log.i("connect", "" + e);
                     Toast.makeText(
                             LoginActivity.this, "" + e.getCode() + ": " + e.getMessage(),
                             Toast.LENGTH_SHORT)
@@ -218,15 +220,25 @@ public class LoginActivity extends AppCompatActivity {
 
                     // Show login failure snackbar
                     showSnackbar("Login to SendBird failed");
-                    mConnectButton.setEnabled(true);
                     PreferenceUtils.setConnected(LoginActivity.this, false);
                     return;
                 }
 
+                if (userData != null) {
+                    Log.i("createmeta", "" + userData);
+                    createUserMetaData(userData);
+                }
+
                 PreferenceUtils.setConnected(LoginActivity.this, true);
+                PreferenceUtils.setUserId(LoginActivity.this.getApplicationContext(), userId);
+                PreferenceUtils.setNickname(LoginActivity.this.getApplicationContext(), userNickname);
 
                 // Update the user's nickname
-                updateCurrentUserInfo(userNickname);
+                if (userData != null) {
+                    updateCurrentUserInfo(userData.get("user_name"));
+                } else {
+                    updateCurrentUserInfo(userNickname);
+                }
                 updateCurrentUserPushToken();
 
                 // Proceed to MainActivity
@@ -235,6 +247,42 @@ public class LoginActivity extends AppCompatActivity {
                 finish();
             }
         });
+    }
+    /* Attaches new user's organization and social profile data, and attaches them to the
+     * sendbird user object. This data can be later accessed by querying for user meta data using a userId.
+     * @param: data - HashMap of user data such as first/last name and profile pic */
+    private void createUserMetaData(HashMap<String, String> data) {
+        User user = SendBird.getCurrentUser();
+        try {
+            if (data.containsKey("user_picture")) {
+                String JSONPicUrl = data.get("user_picture");
+                JSONObject profilePic = new JSONObject(JSONPicUrl);
+                String picURL = (String) profilePic.getJSONObject("data").get("url");
+                SendBird.updateCurrentUserInfo(data.get("user_name"), picURL, new SendBird.UserInfoUpdateHandler() {
+                    @Override
+                    public void onUpdated(SendBirdException e) {
+                        if (e != null) {
+                            // Error!
+                            Toast.makeText(
+                                    LoginActivity.this, "" + e.getCode() + ":" + e.getMessage(),
+                                    Toast.LENGTH_SHORT)
+                                    .show();
+                        }
+
+                    }
+                });
+            }
+            user.updateMetaData(data, new User.MetaDataHandler() {
+                @Override
+                public void onResult(Map<String, String> map, SendBirdException e) {
+                    if (e != null) {    // Error.
+                        Log.i("meta data error", "" + e);
+                    }
+                }
+            });
+        } catch(Exception e) {
+            e.printStackTrace();
+        }
     }
 
     /**
@@ -311,6 +359,6 @@ public class LoginActivity extends AppCompatActivity {
     @Override
     protected void onResume() {
         super.onResume();
-        mFirebaseAuth.addAuthStateListener(mAuthStateListener);
+       mFirebaseAuth.addAuthStateListener(mAuthStateListener);
     }
 }

--- a/app/src/main/java/com/eddierangel/southkern/android/main/MainActivity.java
+++ b/app/src/main/java/com/eddierangel/southkern/android/main/MainActivity.java
@@ -10,6 +10,7 @@ import android.view.MenuItem;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.firebase.ui.auth.AuthUI;
 import com.sendbird.android.SendBird;
 import com.sendbird.android.SendBirdException;
 import com.eddierangel.southkern.android.R;
@@ -70,6 +71,8 @@ public class MainActivity extends AppCompatActivity {
      * then disconnects from SendBird.
      */
     private void disconnect() {
+        AuthUI.getInstance().signOut(this);
+
         SendBird.unregisterPushTokenAllForCurrentUser(new SendBird.UnregisterPushTokenHandler() {
             @Override
             public void onUnregistered(SendBirdException e) {

--- a/app/src/main/java/com/eddierangel/southkern/android/main/UserCreation.java
+++ b/app/src/main/java/com/eddierangel/southkern/android/main/UserCreation.java
@@ -1,0 +1,184 @@
+package com.eddierangel.southkern.android.main;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.design.widget.CoordinatorLayout;
+import android.support.design.widget.TextInputEditText;
+import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
+import android.view.View;
+import android.widget.Button;
+import android.widget.RadioButton;
+import android.widget.Toast;
+
+import com.eddierangel.southkern.android.utils.PreferenceUtils;
+import com.facebook.AccessToken;
+import com.facebook.CallbackManager;
+import com.facebook.FacebookCallback;
+import com.facebook.FacebookException;
+import com.facebook.FacebookSdk;
+import com.facebook.GraphRequest;
+import com.facebook.GraphResponse;
+import com.facebook.HttpMethod;
+import com.facebook.appevents.AppEventsLogger;
+
+import com.eddierangel.southkern.android.R;
+import com.facebook.login.LoginManager;
+import com.facebook.login.LoginResult;
+import com.facebook.login.widget.LoginButton;
+import com.google.android.gms.tasks.Continuation;
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.functions.FirebaseFunctions;
+import com.google.firebase.functions.FirebaseFunctionsException;
+import com.google.firebase.functions.HttpsCallableResult;
+import com.sendbird.android.SendBird;
+import com.sendbird.android.SendBirdException;
+import com.sendbird.android.User;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+
+
+public class UserCreation extends AppCompatActivity {
+
+    private TextInputEditText mUserName, mUserPosition, mUserOrganization;
+    private CoordinatorLayout mLoginLayout;
+    private Button mFinishUserButton;
+    private LoginButton facebookButton;
+    private String EMAIL;
+    private HashMap<String, String> data = new HashMap<String, String>();
+    private CallbackManager callbackManager;
+
+    /* Helper function that converts a JSON string to a HashMap.
+     * @param: String str is the JSON string to convert */
+    public static HashMap<String, String> jsonToMap(String str) throws JSONException {
+
+        HashMap<String, String> map = new HashMap<String, String>();
+        JSONObject jObject = new JSONObject(str);
+        Iterator<?> keys = jObject.keys();
+
+        while( keys.hasNext() ){
+            String key = (String)keys.next();
+            String value = jObject.getString(key);
+            map.put("user_" + key, value);
+
+        }
+
+        return map;
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        setContentView(R.layout.activity_create_user);
+
+        // Facebook initialization
+        FacebookSdk.sdkInitialize(getApplicationContext());
+        AppEventsLogger.activateApp(this);
+        callbackManager = CallbackManager.Factory.create();
+        EMAIL = PreferenceUtils.getUserId(UserCreation.this.getApplicationContext()); // Users log in with email
+
+        mLoginLayout = (CoordinatorLayout) findViewById(R.id.layout_create_user);
+
+        mUserName = (TextInputEditText) findViewById(R.id.create_user_name);
+        mUserPosition = (TextInputEditText) findViewById(R.id.create_user_position);
+        mUserOrganization = (TextInputEditText) findViewById(R.id.create_user_organization);
+
+        mFinishUserButton = (Button) findViewById(R.id.button_user_create);
+
+
+        facebookButton = (LoginButton) findViewById(R.id.login_button);
+        facebookButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                mFinishUserButton.setEnabled(false);
+            }
+        });
+        facebookButton.setReadPermissions("public_profile");
+        LoginManager.getInstance().registerCallback(callbackManager,
+
+            new FacebookCallback<LoginResult>() {
+                @Override
+                public void onSuccess(LoginResult loginResult) {
+                    // Now that we have a token for facebook, we can use that to fetch profile data
+                    Bundle params = new Bundle();
+                    params.putString("fields", "first_name, last_name, picture.type(large), locale, gender, cover");
+                    new GraphRequest(
+                        loginResult.getAccessToken(),
+                        "/" + loginResult.getAccessToken().getUserId() + "/",
+                        params,
+                        HttpMethod.GET,
+                        new GraphRequest.Callback() {
+                            public void onCompleted(GraphResponse response) {
+                                if (response != null) {
+                                    try {
+                                        String resData = response.getRawResponse();
+                                        // Convert JSON String to HashMap using jsonToMap so we can create user meta data
+                                        data = jsonToMap(resData);
+                                        mFinishUserButton.setEnabled(true);
+                                    } catch (Exception e) {
+                                        Log.i("graph err", "" + e);
+                                        e.printStackTrace();
+                                    }
+                                }
+                            }
+                        }
+                    ).executeAsync();
+
+                }
+
+                @Override
+                public void onCancel() {
+                    // App code
+                }
+
+                @Override
+                public void onError(FacebookException exception) {
+                    Log.d("Facebook auth error: ", "" + exception);
+                }
+            });
+
+        mFinishUserButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                String userName = mUserName.getText().toString();
+                String userOrganization = mUserOrganization.getText().toString();
+                String userPosition = mUserPosition.getText().toString();
+
+                data.put("user_name", userName);
+                data.put("user_organization", userOrganization);
+                data.put("user_position", userPosition);
+
+
+                Log.i("data_before", "" + data);
+                Intent returnIntent = new Intent();
+                returnIntent.putExtra("userData", data);
+                setResult(Activity.RESULT_OK, returnIntent);
+                finish();
+            }
+        });
+
+
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        callbackManager.onActivityResult(requestCode, resultCode, data);
+        super.onActivityResult(requestCode, resultCode, data);
+    }
+
+
+}

--- a/app/src/main/java/com/eddierangel/southkern/android/main/UserCreation.java
+++ b/app/src/main/java/com/eddierangel/southkern/android/main/UserCreation.java
@@ -143,11 +143,13 @@ public class UserCreation extends AppCompatActivity {
                 @Override
                 public void onCancel() {
                     // App code
+                    mFinishUserButton.setEnabled(true);
                 }
 
                 @Override
                 public void onError(FacebookException exception) {
                     Log.d("Facebook auth error: ", "" + exception);
+                    mFinishUserButton.setEnabled(true);
                 }
             });
 
@@ -162,8 +164,6 @@ public class UserCreation extends AppCompatActivity {
                 data.put("user_organization", userOrganization);
                 data.put("user_position", userPosition);
 
-
-                Log.i("data_before", "" + data);
                 Intent returnIntent = new Intent();
                 returnIntent.putExtra("userData", data);
                 setResult(Activity.RESULT_OK, returnIntent);

--- a/app/src/main/java/com/eddierangel/southkern/android/utils/PreferenceUtils.java
+++ b/app/src/main/java/com/eddierangel/southkern/android/utils/PreferenceUtils.java
@@ -4,6 +4,8 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 
+import java.util.HashMap;
+
 public class PreferenceUtils {
 
     public static final String PREFERENCE_KEY_USER_ID = "userId";

--- a/app/src/main/java/com/eddierangel/southkern/android/utils/PreferenceUtils.java
+++ b/app/src/main/java/com/eddierangel/southkern/android/utils/PreferenceUtils.java
@@ -4,8 +4,6 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 
-import java.util.HashMap;
-
 public class PreferenceUtils {
 
     public static final String PREFERENCE_KEY_USER_ID = "userId";

--- a/app/src/main/res/layout/activity_create_user.xml
+++ b/app/src/main/res/layout/activity_create_user.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/layout_create_user"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center_horizontal">
+
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="563dp"
+        android:layout_gravity="center"
+        android:layout_marginLeft="@dimen/activity_horizontal_margin"
+        android:layout_marginRight="@dimen/activity_horizontal_margin"
+        android:orientation="vertical">
+
+        <ImageView
+            android:id="@+id/image_user_creation_logo"
+            android:layout_width="50dp"
+            android:layout_height="50dp"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="-5dp"
+            android:src="@drawable/bhc_logo_color_splash" />
+
+        <TextView
+            android:id="@+id/user_create_info_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginTop="10dp"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:text="Tell us a bit about yourself"
+            android:textColor="#000000"
+            android:textSize="24sp" />
+
+        <TextView
+            android:id="@+id/user_create_info_text_subtitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginTop="5dp"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:text="Not interested? Feel free to skip!"
+            android:textColor="#000000"
+            android:textSize="16sp" />
+
+        <android.support.design.widget.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp">
+
+            <android.support.design.widget.TextInputEditText
+                android:id="@+id/create_user_name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="Name"
+                android:imeOptions="actionNext"
+                android:inputType="textVisiblePassword" />
+
+
+        </android.support.design.widget.TextInputLayout>
+
+        <android.support.design.widget.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp">
+
+            <android.support.design.widget.TextInputEditText
+                android:id="@+id/create_user_organization"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="Organization"
+                android:imeOptions="actionDone"
+                android:inputType="textVisiblePassword" />
+
+
+        </android.support.design.widget.TextInputLayout>
+
+        <android.support.design.widget.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp">
+
+            <android.support.design.widget.TextInputEditText
+                android:id="@+id/create_user_position"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="Position"
+                android:imeOptions="actionDone"
+                android:inputType="textVisiblePassword" />
+
+
+        </android.support.design.widget.TextInputLayout>
+
+        <TextView
+            android:id="@+id/social_integration_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="-50dp"
+            android:layout_marginTop="20dp"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:text="Would you like to integrate a social media account?"
+            android:textColor="#000000"
+            android:textSize="16sp" />
+
+        <com.facebook.login.widget.LoginButton
+            android:id="@+id/login_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginBottom="10dp"
+            android:layout_marginTop="90dp" />
+
+        <android.support.v7.widget.AppCompatButton
+            android:id="@+id/button_user_create"
+            style="@style/Widget.AppCompat.Button.Colored"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:text="Done"
+            android:textAllCaps="false"
+            app:theme="@style/AppTheme.ButtonStyle" />
+
+
+    </LinearLayout>
+
+</android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -25,56 +25,6 @@
             android:layout_gravity="center_horizontal"
             android:src="@drawable/login_logo" />
 
-        <android.support.design.widget.TextInputLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="56dp">
-
-            <android.support.design.widget.TextInputEditText
-                android:id="@+id/edittext_login_user_id"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/login_user_id"
-                android:imeOptions="actionNext"
-                android:inputType="textVisiblePassword" />
-
-
-        </android.support.design.widget.TextInputLayout>
-
-
-        <android.support.design.widget.TextInputLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="32dp">
-
-            <android.support.design.widget.TextInputEditText
-                android:id="@+id/edittext_login_user_nickname"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/login_user_nickname"
-                android:imeOptions="actionDone"
-                android:inputType="textVisiblePassword" />
-
-
-        </android.support.design.widget.TextInputLayout>
-
-
-        <android.support.v7.widget.AppCompatButton
-            android:id="@+id/button_login_connect"
-            style="@style/Widget.AppCompat.Button.Colored"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="44dp"
-            android:text="@string/login_connect"
-            app:theme="@style/AppTheme.ButtonStyle"></android.support.v7.widget.AppCompatButton>
-
-        <Button
-            android:id="@+id/button_logout_firebase"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="Log Out" />
-
-
     </LinearLayout>
 
     <android.support.v4.widget.ContentLoadingProgressBar
@@ -82,8 +32,21 @@
         style="?android:attr/progressBarStyleLarge"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center"
+        android:layout_marginBottom="60dp"
+        android:layout_gravity="bottom|center"
         android:visibility="invisible" />
+
+    <TextView
+        android:id="@+id/loading_text"
+        android:textSize="16sp"
+        android:layout_gravity="bottom|center"
+        android:textColor="#000000"
+        android:layout_marginBottom="20dp"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:text="Connecting to messaging service..." />
 
 
 </android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,10 @@
 <resources>
     <string name="app_name">SouthKern</string>
 
+    <!-- Facebook -->
+    <string name="facebook_app_id">296130564334095</string>
+    <string name="fb_login_protocol_scheme">fb296130564334095</string>
+
     <!-- all -->
     <string name="all_app_version">Sample UI v%1$s / SDK v%2$s</string>
 


### PR DESCRIPTION
Reworked auth flow to include first time user set up, and removed a redundant field. UserCreation class allows first time users to immediately set up their profile as they start. If they do not wish to set up a profile they can do so, but will be referenced as a "Guest". They should be able to change their profile settings at a later time.

TODO:
 - Integrating facebook sometimes takes ages (measured seven minutes to log in one time!)
 - Sometimes when you are routed to the main activity after signing in for the first time, you are routed to the main activity twice. Results in buggy looking UX.

How to test:
Login with a new email, and add fields to the user creation or "tell us about you" form. Once you complete your form, send a message in a channel your nickname should be what you put in the "name" field of the form, and if you integrated your facebook account, your profile pic should be your facebook pic. Disconnect (logout) and sign in again. Are you shown the user creation form again? If so that is an error.
