### PR TITLE
Network drop support, bugfixing

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
         <activity android:name=".main.SubmissionManager"/>
         <activity android:name=".openchannel.OpenChatFeed"/>
         <activity android:name=".main.UserList"/>
-        <activity android:name=".utils.FirebaseLoginUI"/>
+        <activity android:name=".utils.ReconnectionManager"/>
         <!-- Facebook start -->
         <meta-data
             tools:replace="android:value"

--- a/app/src/main/java/com/eddierangel/southkern/android/main/CalendarActivity.java
+++ b/app/src/main/java/com/eddierangel/southkern/android/main/CalendarActivity.java
@@ -37,7 +37,9 @@ import com.eddierangel.southkern.android.utils.AlertAdapter;
 import com.eddierangel.southkern.android.utils.CalendarAuthorization;
 import com.eddierangel.southkern.android.utils.EventManager;
 import com.eddierangel.southkern.android.utils.EventParser;
+import com.eddierangel.southkern.android.utils.InternetCheck;
 import com.eddierangel.southkern.android.utils.PreferenceUtils;
+import com.eddierangel.southkern.android.utils.ReconnectionManager;
 import com.google.android.gms.tasks.Continuation;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.OnFailureListener;
@@ -177,587 +179,603 @@ public class CalendarActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        mDatabase = FirebaseDatabase.getInstance().getReference().getRoot();
-
-        User user = SendBird.getCurrentUser();
-        Log.i("userdata", "" + user);
-        final Map<String, String> sendbirdUserData = user.getMetaData();
-
-        CALENDAR_ID = CalendarActivity.this.getApplicationContext().getString(R.string.google_calendar_id);
-        APPLICATION_NAME = CalendarActivity.this.getApplicationContext().getString(R.string.app_name);
-
-        createEventDialogue = new Dialog(CalendarActivity.this);
-        editEventDialogue = new Dialog(CalendarActivity.this);
-        viewEventDialogue = new Dialog(CalendarActivity.this);
-        Log.i("userdata", "" + sendbirdUserData);
-        if (sendbirdUserData.get("user_type") != null) {
-            if (sendbirdUserData.get("user_type").equals("admin")) {
-                Credential credential;
-                CalendarAuthorization calAuth = new CalendarAuthorization();
-                final NetHttpTransport HTTP_TRANSPORT = new com.google.api.client.http.javanet.NetHttpTransport(); // GoogleNetHttpTransport.newTrustedTransport();
-                Context mContext = CalendarActivity.this.getApplicationContext();
-
-                HashMap params = new HashMap();
-                params.put("transport", HTTP_TRANSPORT);
-                params.put("context", mContext);
-                calAuth.execute(params);
-
-                try {
-                    credential = calAuth.get();
-                    service = new Calendar.Builder(HTTP_TRANSPORT, JSON_FACTORY, credential)
-                            .setApplicationName(APPLICATION_NAME)
-                            .build();
-                } catch (Exception e) {
-                    Log.e("credential failed", "" + e);
-                    e.printStackTrace();
-                }
-            }
-        }
-
-        setContentView(R.layout.activity_calendar);
-        mFunctions = FirebaseFunctions.getInstance();
-        mLogo = (ImageView) findViewById(R.id.image_calendar_logo);
-
-        Toolbar toolbar = (Toolbar) findViewById(R.id.calendar_toolbar);
-        setSupportActionBar(toolbar);
-        getSupportActionBar().setDisplayShowTitleEnabled(false);
-
-        createEventDialogue.setContentView(R.layout.dialogue_create_event);
-        createEventDialogue.setTitle(sendbirdUserData.get("user_type").equals("admin") ? "Create Event" : "Create Submission");
-        editEventDialogue.setContentView(R.layout.dialogue_edit_event);
-        editEventDialogue.setTitle(sendbirdUserData.get("user_type").equals("admin") ? "Edit Event" : "Edit Submission");
-        viewEventDialogue.setContentView(R.layout.dialogue_view_event);
-        viewEventDialogue.setTitle("View Event");
-
-        menuButton = (ImageButton) findViewById(R.id.menu_button_calendar);
-        menuButton.setOnClickListener(new View.OnClickListener() {
+        new InternetCheck(new InternetCheck.Consumer() {
             @Override
-            public void onClick(View view) {
-                Intent intent = new Intent(CalendarActivity.this, MainActivity.class);
-                startActivity(intent);
-                finish();
-            }
-        });
-
-        submissionButton = (Button) findViewById(R.id.manage_submissions);
-        submissionButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                Intent intent = new Intent(CalendarActivity.this, SubmissionManager.class);
-                startActivity(intent);
-                finish();
-            }
-        });
-
-        deleteTextView = (TextView) editEventDialogue.findViewById(R.id.delete_text_view);
-        if (sendbirdUserData.get("user_type").equals("admin")) deleteTextView.setVisibility(View.VISIBLE);
-            deleteTextView.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                if (eventToView != null) {
-                    AlertDialog.Builder builder;
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                        builder = new AlertDialog.Builder(CalendarActivity.this, android.R.style.Theme_Material_Dialog_Alert);
-                    } else {
-                        builder = new AlertDialog.Builder(CalendarActivity.this);
-                    }
-                    builder.setTitle("Delete event")
-                            .setMessage("Are you sure you want to delete this event?")
-                            .setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
-                                public void onClick(DialogInterface dialog, int which) {
-                                    HashMap params = new HashMap();
-
-                                    params.put("service", (Object) service);
-                                    params.put("calendarID", CALENDAR_ID);
-                                    params.put("id", eventToView.getId());
-
-                                    List<Event> listOfEvents = events.getItems();
-                                    for (int i = 0 ; i < listOfEvents.size() ; i++) {
-                                        if (listOfEvents.get(i).getId().equals(eventToView.getId())) {
-                                            events.getItems().remove(i);
-                                        }
-                                    }
-
-                                    mWeekView.notifyDatasetChanged();
-                                    editEventDialogue.dismiss();
-
-                                    EventManager.deleteEvent deleteEvent = new EventManager.deleteEvent(CalendarActivity.this);
-
-                                    try {
-                                        deleteEvent.execute(params);
-                                    } catch (Exception e) {
-                                        Log.e("delete event err", "" + e);
-                                        e.printStackTrace();
-                                    }
-                                }
-                            })
-                            .setNegativeButton(android.R.string.no, new DialogInterface.OnClickListener() {
-                                public void onClick(DialogInterface dialog, int which) {
-                                    // do nothing
-                                }
-                            })
-                            .setIcon(android.R.drawable.ic_dialog_alert)
-                            .show();
+            public void accept(Boolean internet) {
+                if (!internet) {
+                    Intent intent = new Intent(CalendarActivity.this, ReconnectionManager.class);
+                    startActivity(intent);
+                    finish();
                 } else {
-                    throw new NullPointerException("eventToView does not exist");
-                }
-            }
-        });
 
-        selectTimeButton = (Button) createEventDialogue.findViewById(R.id.button_select_time);
-        selectTimeButtonEdit = (Button) editEventDialogue.findViewById(R.id.button_select_time_edit);
-        mTimePicker = new TimePickerDialog(CalendarActivity.this, new TimePickerDialog.OnTimeSetListener() {
-            @Override
-            public void onTimeSet(TimePicker timePicker, int selectedHour, int selectedMinute) {
-                hour = selectedHour;
-                minute = selectedMinute;
-                if (editTimeButtonClicked) {
-                    selectTimeButtonEdit.setText(String.format(hour - 12 > 0 ? "Ending at %d:%02d PM" : "Ending at %d:%02d AM", convertTimeType(hour), minute));
-                } else {
-                    selectTimeButton.setText(String.format(hour - 12 > 0 ? "Ending at %d:%02d PM" : "Ending at %d:%02d AM", convertTimeType(hour), minute));
-                }
+                    mDatabase = FirebaseDatabase.getInstance().getReference().getRoot();
 
-            }
-        }, hour, minute, false); // No 24 hour time
-        selectTimeButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                editTimeButtonClicked = false;
-                mTimePicker.setTitle("Select Event End Time");
-                mTimePicker.show();
-            }
-        });
+                    User user = SendBird.getCurrentUser();
+                    Log.i("userdata", "" + user);
+                    final Map<String, String> sendbirdUserData = user.getMetaData();
 
-        selectTimeButtonEdit.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                editTimeButtonClicked = true;
-                mTimePicker.setTitle("Edit Event End Time");
-                mTimePicker.show();
-            }
-        });
+                    CALENDAR_ID = CalendarActivity.this.getApplicationContext().getString(R.string.google_calendar_id);
+                    APPLICATION_NAME = CalendarActivity.this.getApplicationContext().getString(R.string.app_name);
 
-        createEventButton = (Button) createEventDialogue.findViewById(R.id.button_create_event);
-        createEventButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                eventName = (EditText) createEventDialogue.findViewById(R.id.event_name_create);
-                eventLocation = (EditText) createEventDialogue.findViewById(R.id.event_location_create);
-                eventDescription = (EditText)  createEventDialogue.findViewById((R.id.event_description_create));
+                    createEventDialogue = new Dialog(CalendarActivity.this);
+                    editEventDialogue = new Dialog(CalendarActivity.this);
+                    viewEventDialogue = new Dialog(CalendarActivity.this);
+                    Log.i("userdata", "" + sendbirdUserData);
+                    if (sendbirdUserData.get("user_type") != null) {
+                        if (sendbirdUserData.get("user_type").equals("admin")) {
+                            Credential credential;
+                            CalendarAuthorization calAuth = new CalendarAuthorization();
+                            final NetHttpTransport HTTP_TRANSPORT = new com.google.api.client.http.javanet.NetHttpTransport(); // GoogleNetHttpTransport.newTrustedTransport();
+                            Context mContext = CalendarActivity.this.getApplicationContext();
 
-                if (hour != 0 && eventName.length() != 0) {
-                    String name = eventName.getText().toString();
-                    String location = eventLocation.getText().toString();
-                    String description = eventDescription.getText().toString();
+                            HashMap params = new HashMap();
+                            params.put("transport", HTTP_TRANSPORT);
+                            params.put("context", mContext);
+                            calAuth.execute(params);
 
-                    java.util.Calendar calendar = java.util.Calendar.getInstance();
-                    calendar.set(timePressed.get(java.util.Calendar.YEAR), timePressed.get(java.util.Calendar.MONTH), timePressed.get(java.util.Calendar.DATE), hour, minute);
-                    DateTime endTime = new DateTime(calendar.getTime());
-                    DateTime startTime = new DateTime(timePressed.getTime());
-
-                    EventDateTime eventStartTime = new EventDateTime().setDateTime(startTime);
-                    EventDateTime eventEndTime = new EventDateTime().setDateTime(endTime);
-
-                    Event dummyEvent = new Event();
-                    dummyEvent.setSummary(name);
-                    dummyEvent.setDescription(description);
-                    dummyEvent.setLocation(location);
-                    dummyEvent.setStart(eventStartTime);
-                    dummyEvent.setEnd(eventEndTime);
-
-                    // Perform optimistic UI update
-                    if (sendbirdUserData.get("user_type").equals("admin")) {
-                        events.getItems().add(dummyEvent);
-                        mWeekView.notifyDatasetChanged();
-                    }
-
-                    HashMap params = new HashMap();
-                    params.put("service", (Object) service);
-                    params.put("event", (Object) dummyEvent);
-                    params.put("calendarID", CALENDAR_ID);
-
-                    if (sendbirdUserData.get("user_type").equals("admin")) {
-                        EventManager.insertEvent insertEvent = new EventManager.insertEvent(CalendarActivity.this);
-
-                        try {
-                            insertEvent.execute(params);
-                        } catch (Exception e) {
-                            Log.e("insert event err", "" + e);
-                            e.printStackTrace();
-                        }
-                    } else {
-                        Event.Creator dummyCreator = new Event.Creator();
-                        dummyCreator.setDisplayName(sendbirdUserData.get("user_name"));
-                        dummyEvent.setCreator(dummyCreator);
-                        Log.i("created sub", "" + dummyCreator);
-                        mDatabase.child("submissions").child(name).setValue(dummyEvent).addOnFailureListener(new OnFailureListener() {
-                            @Override
-                            public void onFailure(@NonNull Exception e) {
-                                //Failed
-                                Log.i("database", "" + e);
+                            try {
+                                credential = calAuth.get();
+                                service = new Calendar.Builder(HTTP_TRANSPORT, JSON_FACTORY, credential)
+                                        .setApplicationName(APPLICATION_NAME)
+                                        .build();
+                            } catch (Exception e) {
+                                Log.e("credential failed", "" + e);
                                 e.printStackTrace();
                             }
-                        });
-                    }
-
-                    createEventDialogue.dismiss();
-                    hour = 0;
-                    minute = 0;
-                    eventName = (EditText) createEventDialogue.findViewById(R.id.event_name_create);
-                    eventLocation = (EditText) createEventDialogue.findViewById(R.id.event_location_create);
-                    eventDescription = (EditText)  createEventDialogue.findViewById((R.id.event_description_create));
-
-                    eventName.setText("");
-                    eventLocation.setText("");
-                    eventDescription.setText("");
-                    selectTimeButton.setText("Edit event end time");
-                } else {
-                    Toast.makeText(CalendarActivity.this, "Please enter an end time.", Toast.LENGTH_SHORT).show();
-                }
-
-            }
-        });
-
-        editEventButton = (Button) editEventDialogue.findViewById(R.id.button_edit_event);
-        editEventButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                java.util.Calendar calendar = java.util.Calendar.getInstance();
-                if (hour != 0) {
-                    calendar = java.util.Calendar.getInstance();
-                    calendar.set(eventStart.get(java.util.Calendar.YEAR),
-                            eventStart.get(java.util.Calendar.MONTH),
-                            eventStart.get(java.util.Calendar.DATE), hour, minute);
-                }
-
-                editEventName = (EditText) editEventDialogue.findViewById(R.id.event_name_edit);
-                editEventLocation = (EditText) editEventDialogue.findViewById(R.id.event_location_edit);
-                editEventDescription = (EditText) editEventDialogue.findViewById(R.id.event_description_edit);
-
-                String newEventName = editEventName.getText().toString();
-                String newEventLocation = editEventLocation.getText().toString();
-                String newEventDescription = editEventDescription.getText().toString();
-                DateTime newEventEndTime = new DateTime(0);
-                if (hour != 0) {
-                    newEventEndTime = new DateTime(calendar.getTime());
-                }
-
-                HashMap params = new HashMap();
-                params.put("name", newEventName);
-                params.put("location", newEventLocation);
-                params.put("description", newEventDescription);
-                params.put("id", eventToView.getId());
-                params.put("service", service);
-                params.put("calendarID", CALENDAR_ID);
-
-                if (hour != 0) {
-                    params.put("end", newEventEndTime);
-                }
-
-                // Perform optimistic UI update
-                List<Event> listOfEvents = events.getItems();
-                for (int i = 0 ; i < listOfEvents.size() ; i++) {
-                    if (listOfEvents.get(i).getId().equals(eventToView.getId())) {
-                        Event dummyEvent = events.getItems().get(i);
-                        dummyEvent.setSummary(newEventName);
-                        dummyEvent.setLocation(newEventLocation);
-                        dummyEvent.setDescription(newEventDescription);
-                        if (hour != 0) {
-                            dummyEvent.setEnd(new EventDateTime().setDate(newEventEndTime));
-                            dummyEvent.setStart(eventToView.getStart());
                         }
                     }
-                }
 
-                mWeekView.notifyDatasetChanged();
+                    setContentView(R.layout.activity_calendar);
+                    mFunctions = FirebaseFunctions.getInstance();
+                    mLogo = (ImageView) findViewById(R.id.image_calendar_logo);
 
-                EventManager.updateEvent updateEvent = new EventManager.updateEvent(CalendarActivity.this);
+                    Toolbar toolbar = (Toolbar) findViewById(R.id.calendar_toolbar);
+                    setSupportActionBar(toolbar);
+                    getSupportActionBar().setDisplayShowTitleEnabled(false);
 
-                try {
-                    updateEvent.execute(params);
-                } catch(Exception e) {
-                    Log.e("update error", "" + e);
-                    e.printStackTrace();
-                }
+                    createEventDialogue.setContentView(R.layout.dialogue_create_event);
+                    createEventDialogue.setTitle(sendbirdUserData.get("user_type").equals("admin") ? "Create Event" : "Create Submission");
+                    editEventDialogue.setContentView(R.layout.dialogue_edit_event);
+                    editEventDialogue.setTitle(sendbirdUserData.get("user_type").equals("admin") ? "Edit Event" : "Edit Submission");
+                    viewEventDialogue.setContentView(R.layout.dialogue_view_event);
+                    viewEventDialogue.setTitle("View Event");
 
-                editEventDialogue.dismiss();
-                hour = 0;
-                minute = 0;
-            }
-        });
-
-
-        // Get a reference for the week view in the layout.
-        mWeekView = (WeekView) findViewById(R.id.weekView);
-        mWeekView.setVisibility(View.GONE);
-
-        createEventTitle = (TextView) createEventDialogue.findViewById(R.id.create_event_title);
-         if(!sendbirdUserData.get("user_type").equals("admin")) { createEventTitle.setText("Create submission"); createEventTitle.setTextSize(20); }
-
-        progressBarCalendar = (ProgressBar) findViewById(R.id.progressBarCalendar);
-        progressBarCalendar.setEnabled(true);
-
-        alertNavView = (NavigationView) findViewById(R.id.nav_view_alerts);
-
-        getCalendarEvents(PreferenceUtils.getFirebaseToken(this.getApplicationContext()))
-                .addOnCompleteListener(new OnCompleteListener<Events>() {
-                    @Override
-                    public void onComplete(@NonNull Task<Events> task) {
-                        if (!task.isSuccessful()) {
-                            Exception e = task.getException();
-                            if (e instanceof FirebaseFunctionsException) {
-                                FirebaseFunctionsException ffe = (FirebaseFunctionsException) e;
-                                FirebaseFunctionsException.Code code = ffe.getCode();
-                                Object details = ffe.getDetails();
-                            }
+                    menuButton = (ImageButton) findViewById(R.id.menu_button_calendar);
+                    menuButton.setOnClickListener(new View.OnClickListener() {
+                        @Override
+                        public void onClick(View view) {
+                            Intent intent = new Intent(CalendarActivity.this, MainActivity.class);
+                            startActivity(intent);
+                            finish();
                         }
-                        // Success
-                        events = task.getResult();
+                    });
 
-                        // Set time on calendar to the time of the first event. This stops the calendar from starting at weird times such
-                        // as 1 AM which could cause confusion.
-                        String start = events.getItems().get(0).getStart().getDate().toString();
-                        String hours = start.substring(11, 13);
-                        String minutes = start.substring(14, 16);
-                        double timeToStart = Double.parseDouble(hours + "." + minutes);
-                        mWeekView.goToHour(timeToStart - 2.0);
+                    submissionButton = (Button) findViewById(R.id.manage_submissions);
+                    submissionButton.setOnClickListener(new View.OnClickListener() {
+                        @Override
+                        public void onClick(View view) {
+                            Intent intent = new Intent(CalendarActivity.this, SubmissionManager.class);
+                            startActivity(intent);
+                            finish();
+                        }
+                    });
 
-                        mLogo.setVisibility(View.VISIBLE);
-                        mWeekView.setVisibility(View.VISIBLE);
-                        createEventButton.setVisibility(View.VISIBLE);
-
-                        alertRecyclerView = (RecyclerView) findViewById(R.id.alert_recycler_view);
-                        RecyclerView.LayoutManager mLayoutAlertManager = new LinearLayoutManager(getApplicationContext());
-                        alertRecyclerView.setLayoutManager(mLayoutAlertManager);
-                        alertRecyclerView.setItemAnimator(new DefaultItemAnimator());
-                        alertAdapter = new AlertAdapter(alertEvents);
-                        alertRecyclerView.setAdapter(alertAdapter);
-
-                        viewAlertButton = (ImageButton) findViewById(R.id.alert_view_button);
-                        viewAlertButton.setOnClickListener(new View.OnClickListener() {
-                            @Override
-                            public void onClick(View view) {
-                                alertNavView.setVisibility(alertNavView.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
-                                viewAlertButton.setBackgroundColor(alertNavView.getVisibility() == View.VISIBLE ? Color.DKGRAY : Color.TRANSPARENT);
-
-                            }
-                        });
-
-                        mDatabase.child("statusUpdates").addValueEventListener(new ValueEventListener() {
-                            @Override
-                            public void onDataChange(@NonNull DataSnapshot dataSnapshot) {
-
-                                for (DataSnapshot mSnapshot : dataSnapshot.getChildren()) {
-                                    HashMap statusObj = (HashMap) mSnapshot.getValue();
-                                    Event tempEvent = new Event();
-                                    tempEvent.setDescription((String) statusObj.get("text"));
-                                    tempEvent.setSummary("Status update");
-
-                                    EventDateTime dummyTime = new EventDateTime();
-                                    Long dateTime = Long.parseLong(statusObj.get("createdAt").toString());
-                                    DateTime createdAtTime = new DateTime(dateTime);
-                                    dummyTime.setDate(createdAtTime);
-                                    tempEvent.setStart(dummyTime);
-
-                                    if (!alertEvents.contains(tempEvent) && tempEvent.getStart().getDate().getValue() > (twoWeekTime / 2)) {
-                                        alertEvents.add(tempEvent);
-                                    }
-
+                    deleteTextView = (TextView) editEventDialogue.findViewById(R.id.delete_text_view);
+                    if (sendbirdUserData.get("user_type").equals("admin"))
+                        deleteTextView.setVisibility(View.VISIBLE);
+                    deleteTextView.setOnClickListener(new View.OnClickListener() {
+                        @Override
+                        public void onClick(View view) {
+                            if (eventToView != null) {
+                                AlertDialog.Builder builder;
+                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                                    builder = new AlertDialog.Builder(CalendarActivity.this, android.R.style.Theme_Material_Dialog_Alert);
+                                } else {
+                                    builder = new AlertDialog.Builder(CalendarActivity.this);
                                 }
+                                builder.setTitle("Delete event")
+                                        .setMessage("Are you sure you want to delete this event?")
+                                        .setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
+                                            public void onClick(DialogInterface dialog, int which) {
+                                                HashMap params = new HashMap();
 
-                                Collections.reverse(alertEvents);
+                                                params.put("service", (Object) service);
+                                                params.put("calendarID", CALENDAR_ID);
+                                                params.put("id", eventToView.getId());
 
-                                alertAdapter.notifyDataSetChanged();
+                                                List<Event> listOfEvents = events.getItems();
+                                                for (int i = 0; i < listOfEvents.size(); i++) {
+                                                    if (listOfEvents.get(i).getId().equals(eventToView.getId())) {
+                                                        events.getItems().remove(i);
+                                                    }
+                                                }
+
+                                                mWeekView.notifyDatasetChanged();
+                                                editEventDialogue.dismiss();
+
+                                                EventManager.deleteEvent deleteEvent = new EventManager.deleteEvent(CalendarActivity.this);
+
+                                                try {
+                                                    deleteEvent.execute(params);
+                                                } catch (Exception e) {
+                                                    Log.e("delete event err", "" + e);
+                                                    e.printStackTrace();
+                                                }
+                                            }
+                                        })
+                                        .setNegativeButton(android.R.string.no, new DialogInterface.OnClickListener() {
+                                            public void onClick(DialogInterface dialog, int which) {
+                                                // do nothing
+                                            }
+                                        })
+                                        .setIcon(android.R.drawable.ic_dialog_alert)
+                                        .show();
+                            } else {
+                                throw new NullPointerException("eventToView does not exist");
+                            }
+                        }
+                    });
+
+                    selectTimeButton = (Button) createEventDialogue.findViewById(R.id.button_select_time);
+                    selectTimeButtonEdit = (Button) editEventDialogue.findViewById(R.id.button_select_time_edit);
+                    mTimePicker = new TimePickerDialog(CalendarActivity.this, new TimePickerDialog.OnTimeSetListener() {
+                        @Override
+                        public void onTimeSet(TimePicker timePicker, int selectedHour, int selectedMinute) {
+                            hour = selectedHour;
+                            minute = selectedMinute;
+                            if (editTimeButtonClicked) {
+                                selectTimeButtonEdit.setText(String.format(hour - 12 > 0 ? "Ending at %d:%02d PM" : "Ending at %d:%02d AM", convertTimeType(hour), minute));
+                            } else {
+                                selectTimeButton.setText(String.format(hour - 12 > 0 ? "Ending at %d:%02d PM" : "Ending at %d:%02d AM", convertTimeType(hour), minute));
                             }
 
-                            @Override
-                            public void onCancelled(@NonNull DatabaseError databaseError) {
+                        }
+                    }, hour, minute, false); // No 24 hour time
+                    selectTimeButton.setOnClickListener(new View.OnClickListener() {
+                        @Override
+                        public void onClick(View view) {
+                            editTimeButtonClicked = false;
+                            mTimePicker.setTitle("Select Event End Time");
+                            mTimePicker.show();
+                        }
+                    });
 
-                            }
-                        });
+                    selectTimeButtonEdit.setOnClickListener(new View.OnClickListener() {
+                        @Override
+                        public void onClick(View view) {
+                            editTimeButtonClicked = true;
+                            mTimePicker.setTitle("Edit Event End Time");
+                            mTimePicker.show();
+                        }
+                    });
 
-                        if (sendbirdUserData.get("user_type").equals("admin")) {
-                            submissionButton.setVisibility(View.VISIBLE);
-                        } else {
-                            final String username = sendbirdUserData.get("user_name");
-                            mDatabase.child("submissions").addValueEventListener(new ValueEventListener() {
-                                @Override
-                                public void onDataChange(@NonNull DataSnapshot dataSnapshot) {
-                                    Log.i("databaseval", "" + dataSnapshot.getValue());
-                                    listOfSubmissions.clear();
-                                    for (DataSnapshot mSnapshot : dataSnapshot.getChildren()) {
-                                        Log.i("databaseval2", "" + mSnapshot.getValue());
-                                        Event event = EventParser.parseSingleEvent(mSnapshot.getValue());
-                                        if (event.getCreator().getDisplayName().equals(username)) {
-                                            listOfSubmissions.add(event);
-                                        }
-                                    }
+                    createEventButton = (Button) createEventDialogue.findViewById(R.id.button_create_event);
+                    createEventButton.setOnClickListener(new View.OnClickListener() {
+                        @Override
+                        public void onClick(View view) {
+                            eventName = (EditText) createEventDialogue.findViewById(R.id.event_name_create);
+                            eventLocation = (EditText) createEventDialogue.findViewById(R.id.event_location_create);
+                            eventDescription = (EditText) createEventDialogue.findViewById((R.id.event_description_create));
+
+                            if (hour != 0 && eventName.length() != 0) {
+                                String name = eventName.getText().toString();
+                                String location = eventLocation.getText().toString();
+                                String description = eventDescription.getText().toString();
+
+                                java.util.Calendar calendar = java.util.Calendar.getInstance();
+                                calendar.set(timePressed.get(java.util.Calendar.YEAR), timePressed.get(java.util.Calendar.MONTH), timePressed.get(java.util.Calendar.DATE), hour, minute);
+                                DateTime endTime = new DateTime(calendar.getTime());
+                                DateTime startTime = new DateTime(timePressed.getTime());
+
+                                EventDateTime eventStartTime = new EventDateTime().setDateTime(startTime);
+                                EventDateTime eventEndTime = new EventDateTime().setDateTime(endTime);
+
+                                Event dummyEvent = new Event();
+                                dummyEvent.setSummary(name);
+                                dummyEvent.setDescription(description);
+                                dummyEvent.setLocation(location);
+                                dummyEvent.setStart(eventStartTime);
+                                dummyEvent.setEnd(eventEndTime);
+
+                                // Perform optimistic UI update
+                                if (sendbirdUserData.get("user_type").equals("admin")) {
+                                    events.getItems().add(dummyEvent);
                                     mWeekView.notifyDatasetChanged();
                                 }
 
-                                @Override
-                                public void onCancelled(@NonNull DatabaseError databaseError) {
+                                HashMap params = new HashMap();
+                                params.put("service", (Object) service);
+                                params.put("event", (Object) dummyEvent);
+                                params.put("calendarID", CALENDAR_ID);
 
+                                if (sendbirdUserData.get("user_type").equals("admin")) {
+                                    EventManager.insertEvent insertEvent = new EventManager.insertEvent(CalendarActivity.this);
+
+                                    try {
+                                        insertEvent.execute(params);
+                                    } catch (Exception e) {
+                                        Log.e("insert event err", "" + e);
+                                        e.printStackTrace();
+                                    }
+                                } else {
+                                    Event.Creator dummyCreator = new Event.Creator();
+                                    dummyCreator.setDisplayName(sendbirdUserData.get("user_name"));
+                                    dummyEvent.setCreator(dummyCreator);
+                                    Log.i("created sub", "" + dummyCreator);
+                                    mDatabase.child("submissions").child(name).setValue(dummyEvent).addOnFailureListener(new OnFailureListener() {
+                                        @Override
+                                        public void onFailure(@NonNull Exception e) {
+                                            //Failed
+                                            Log.i("database", "" + e);
+                                            e.printStackTrace();
+                                        }
+                                    });
                                 }
-                            });
+
+                                createEventDialogue.dismiss();
+                                hour = 0;
+                                minute = 0;
+                                eventName = (EditText) createEventDialogue.findViewById(R.id.event_name_create);
+                                eventLocation = (EditText) createEventDialogue.findViewById(R.id.event_location_create);
+                                eventDescription = (EditText) createEventDialogue.findViewById((R.id.event_description_create));
+
+                                eventName.setText("");
+                                eventLocation.setText("");
+                                eventDescription.setText("");
+                                selectTimeButton.setText("Edit event end time");
+                            } else {
+                                Toast.makeText(CalendarActivity.this, "Please enter an end time.", Toast.LENGTH_SHORT).show();
+                            }
+
                         }
-                        progressBarCalendar.setVisibility(View.GONE);
+                    });
+
+                    editEventButton = (Button) editEventDialogue.findViewById(R.id.button_edit_event);
+                    editEventButton.setOnClickListener(new View.OnClickListener() {
+                        @Override
+                        public void onClick(View view) {
+                            java.util.Calendar calendar = java.util.Calendar.getInstance();
+                            if (hour != 0) {
+                                calendar = java.util.Calendar.getInstance();
+                                calendar.set(eventStart.get(java.util.Calendar.YEAR),
+                                        eventStart.get(java.util.Calendar.MONTH),
+                                        eventStart.get(java.util.Calendar.DATE), hour, minute);
+                            }
+
+                            editEventName = (EditText) editEventDialogue.findViewById(R.id.event_name_edit);
+                            editEventLocation = (EditText) editEventDialogue.findViewById(R.id.event_location_edit);
+                            editEventDescription = (EditText) editEventDialogue.findViewById(R.id.event_description_edit);
+
+                            String newEventName = editEventName.getText().toString();
+                            String newEventLocation = editEventLocation.getText().toString();
+                            String newEventDescription = editEventDescription.getText().toString();
+                            DateTime newEventEndTime = new DateTime(0);
+                            if (hour != 0) {
+                                newEventEndTime = new DateTime(calendar.getTime());
+                            }
+
+                            HashMap params = new HashMap();
+                            params.put("name", newEventName);
+                            params.put("location", newEventLocation);
+                            params.put("description", newEventDescription);
+                            params.put("id", eventToView.getId());
+                            params.put("service", service);
+                            params.put("calendarID", CALENDAR_ID);
+
+                            if (hour != 0) {
+                                params.put("end", newEventEndTime);
+                            }
+
+                            // Perform optimistic UI update
+                            List<Event> listOfEvents = events.getItems();
+                            for (int i = 0; i < listOfEvents.size(); i++) {
+                                if (listOfEvents.get(i).getId().equals(eventToView.getId())) {
+                                    Event dummyEvent = events.getItems().get(i);
+                                    dummyEvent.setSummary(newEventName);
+                                    dummyEvent.setLocation(newEventLocation);
+                                    dummyEvent.setDescription(newEventDescription);
+                                    if (hour != 0) {
+                                        dummyEvent.setEnd(new EventDateTime().setDate(newEventEndTime));
+                                        dummyEvent.setStart(eventToView.getStart());
+                                    }
+                                }
+                            }
+
+                            mWeekView.notifyDatasetChanged();
+
+                            EventManager.updateEvent updateEvent = new EventManager.updateEvent(CalendarActivity.this);
+
+                            try {
+                                updateEvent.execute(params);
+                            } catch (Exception e) {
+                                Log.e("update error", "" + e);
+                                e.printStackTrace();
+                            }
+
+                            editEventDialogue.dismiss();
+                            hour = 0;
+                            minute = 0;
+                        }
+                    });
+
+
+                    // Get a reference for the week view in the layout.
+                    mWeekView = (WeekView) findViewById(R.id.weekView);
+                    mWeekView.setVisibility(View.GONE);
+
+                    createEventTitle = (TextView) createEventDialogue.findViewById(R.id.create_event_title);
+                    if (!sendbirdUserData.get("user_type").equals("admin")) {
+                        createEventTitle.setText("Create submission");
+                        createEventTitle.setTextSize(20);
                     }
-                });
 
-        closeViewDialogueButton = (Button) viewEventDialogue.findViewById(R.id.finish_viewing_button);
-        closeViewDialogueButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                viewEventDialogue.dismiss();
-            }
-        });
+                    progressBarCalendar = (ProgressBar) findViewById(R.id.progressBarCalendar);
+                    progressBarCalendar.setEnabled(true);
 
-        WeekView.EventLongPressListener eventLongPressListener = new WeekView.EventLongPressListener() {
-            @Override
-            public void onEventLongPress(WeekViewEvent event, RectF eventRect) {
-                // If the event color is gray, it is in the process of being created and does not yet exist in the google calendar.
-                // because of this, we do not allow gray events to be edited.
-                if (event.getColor() == Color.GRAY) return;
-                // TODO: add validation to the case where event does not have a name. (event.getName() returns null reference)
-                for (Event eventObj : events.getItems()) {
-                    if (event.getName().equals(eventObj.getSummary())) {
-                        eventToView = eventObj;
-                    }
-                }
-                eventStart = event.getStartTime();
-                DateFormat df = new SimpleDateFormat("h:mm");
-                String sdt;
-                if (eventToView.getEnd().getDate() != null) {
-                    sdt = df.format(new Date(eventToView.getEnd().getDate().getValue()));
-                } else {
-                    sdt = df.format(new Date(eventToView.getEnd().getDateTime().getValue()));
-                }
+                    alertNavView = (NavigationView) findViewById(R.id.nav_view_alerts);
 
-                if (sendbirdUserData.get("user_type").equals("admin")) {
-                    editEventName = (EditText) editEventDialogue.findViewById(R.id.event_name_edit);
-                    editEventLocation = (EditText) editEventDialogue.findViewById(R.id.event_location_edit);
-                    editEventDescription = (EditText) editEventDialogue.findViewById(R.id.event_description_edit);
+                    getCalendarEvents(PreferenceUtils.getFirebaseToken(CalendarActivity.this.getApplicationContext()))
+                            .addOnCompleteListener(new OnCompleteListener<Events>() {
+                                @Override
+                                public void onComplete(@NonNull Task<Events> task) {
+                                    if (!task.isSuccessful()) {
+                                        Exception e = task.getException();
+                                        if (e instanceof FirebaseFunctionsException) {
+                                            FirebaseFunctionsException ffe = (FirebaseFunctionsException) e;
+                                            FirebaseFunctionsException.Code code = ffe.getCode();
+                                            Object details = ffe.getDetails();
+                                        }
+                                    }
+                                    // Success
+                                    events = task.getResult();
 
-                    editEventName.setText(eventToView.getSummary());
-                    editEventLocation.setText(eventToView.getLocation());
-                    editEventDescription.setText(eventToView.getDescription());
-                    selectTimeButtonEdit.setText("Ending at " + sdt);
+                                    // Set time on calendar to the time of the first event. This stops the calendar from starting at weird times such
+                                    // as 1 AM which could cause confusion.
+                                    String start = events.getItems().get(0).getStart().getDate().toString();
+                                    String hours = start.substring(11, 13);
+                                    String minutes = start.substring(14, 16);
+                                    double timeToStart = Double.parseDouble(hours + "." + minutes);
+                                    mWeekView.goToHour(timeToStart - 2.0);
 
-                    editEventDialogue.show();
-                } else {
-                    viewEventName = (TextView) viewEventDialogue.findViewById(R.id.event_name_view);
-                    viewEventLocation = (TextView) viewEventDialogue.findViewById(R.id.event_location_view);
-                    viewEventDescription = (TextView) viewEventDialogue.findViewById(R.id.event_description_view);
+                                    mLogo.setVisibility(View.VISIBLE);
+                                    mWeekView.setVisibility(View.VISIBLE);
+                                    createEventButton.setVisibility(View.VISIBLE);
 
-                    viewEventName.setText(eventToView.getSummary());
-                    viewEventLocation.setText(eventToView.getLocation());
-                    viewEventDescription.setText(eventToView.getDescription());
+                                    alertRecyclerView = (RecyclerView) findViewById(R.id.alert_recycler_view);
+                                    RecyclerView.LayoutManager mLayoutAlertManager = new LinearLayoutManager(getApplicationContext());
+                                    alertRecyclerView.setLayoutManager(mLayoutAlertManager);
+                                    alertRecyclerView.setItemAnimator(new DefaultItemAnimator());
+                                    alertAdapter = new AlertAdapter(alertEvents);
+                                    alertRecyclerView.setAdapter(alertAdapter);
 
-                    viewEventDialogue.show();
-                }
-            }
-        };
-        mWeekView.setEventLongPressListener(eventLongPressListener);
+                                    viewAlertButton = (ImageButton) findViewById(R.id.alert_view_button);
+                                    viewAlertButton.setOnClickListener(new View.OnClickListener() {
+                                        @Override
+                                        public void onClick(View view) {
+                                            alertNavView.setVisibility(alertNavView.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
+                                            viewAlertButton.setBackgroundColor(alertNavView.getVisibility() == View.VISIBLE ? Color.DKGRAY : Color.TRANSPARENT);
 
-        WeekView.EmptyViewLongPressListener emptyViewLongPressListener = new WeekView.EmptyViewLongPressListener() {
-            @Override
-            public void onEmptyViewLongPress(java.util.Calendar time) {
-                timePressed = time;
-                createEventDialogue.show();
-            }
-        };
-        mWeekView.setEmptyViewLongPressListener(emptyViewLongPressListener);
+                                        }
+                                    });
 
-        /* TODO: assign event id to weekview id. its possible two events will have the same name. */
-        MonthLoader.MonthChangeListener mMonthChangeListener = new MonthLoader.MonthChangeListener() {
-            @Override
-            public List<WeekViewEvent> onMonthChange(int newYear, int newMonth) {
-                // Populate the week view with some events.
-                List<WeekViewEvent> filteredEvents = new ArrayList<WeekViewEvent>();
-                Event dummyEvent = new Event();
-                if (events != null) {
-                    List<Event> listOfEvents = getEvents(newYear, newMonth);
-                    Class aClass = dummyEvent.getClass();
-                    for (Event event : listOfEvents) {
-                        WeekViewEvent weekEvent = new WeekViewEvent();
-                        for (Field field : aClass.getDeclaredFields()) {
-                            field.setAccessible(true);
-                            Log.i("field", "" + field.getName());
-                                switch(field.getName()) {
-                                    case "end":
-                                            java.util.Calendar endCalendar = new GregorianCalendar();
-                                            String end;
-                                            if (event.getEnd().getDate() != null) {
-                                                end = event.getEnd().getDate().toString();
-                                            } else {
-                                                end = event.getEnd().getDateTime().toString();
+                                    mDatabase.child("statusUpdates").addValueEventListener(new ValueEventListener() {
+                                        @Override
+                                        public void onDataChange(@NonNull DataSnapshot dataSnapshot) {
+
+                                            for (DataSnapshot mSnapshot : dataSnapshot.getChildren()) {
+                                                HashMap statusObj = (HashMap) mSnapshot.getValue();
+                                                Event tempEvent = new Event();
+                                                tempEvent.setDescription((String) statusObj.get("text"));
+                                                tempEvent.setSummary("Status update");
+
+                                                EventDateTime dummyTime = new EventDateTime();
+                                                Long dateTime = Long.parseLong(statusObj.get("createdAt").toString());
+                                                DateTime createdAtTime = new DateTime(dateTime);
+                                                dummyTime.setDate(createdAtTime);
+                                                tempEvent.setStart(dummyTime);
+
+                                                if (!alertEvents.contains(tempEvent) && tempEvent.getStart().getDate().getValue() > (twoWeekTime / 2)) {
+                                                    alertEvents.add(tempEvent);
+                                                }
+
                                             }
-                                            SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-                                            Date date = new Date();
-                                            Long endMillis = 0L;
-                                            try {
-                                                date = simpleDateFormat.parse(end);
-                                                endMillis = date.getTime();
-                                            } catch (ParseException e) {
-                                                Log.e("err", "" + e);
-                                            }
-                                            endCalendar.setTimeInMillis(endMillis);
-                                            weekEvent.setEndTime(endCalendar);
 
-                                    case "start":
-                                            java.util.Calendar startCalendar = new GregorianCalendar();
-                                            String start;
-                                            if (event.getStart().getDate() != null) {
-                                                start = event.getStart().getDate().toString();
-                                            } else {
-                                                start  = event.getStart().getDateTime().toString();
-                                            }
-                                            SimpleDateFormat simpleDateFormatStart = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-                                            Date startDate = new Date();
-                                            Long startMillis = 0L;
-                                            try {
-                                                startDate = simpleDateFormatStart.parse(start);
-                                                startMillis = startDate.getTime();
-                                            } catch (ParseException e) {
-                                                Log.e("err", "" + e);
-                                            }
-                                            startCalendar.setTimeInMillis(startMillis);
-                                            weekEvent.setStartTime(startCalendar);
+                                            Collections.reverse(alertEvents);
 
-                                    case "id":
-                                        if (event.getEtag() != null) {
-                                            weekEvent.setId(Long.parseLong(event.getEtag().replace("\"", "")));
-                                        } else {
-                                            weekEvent.setId(new Random().nextInt(20000) + 1000);
+                                            alertAdapter.notifyDataSetChanged();
                                         }
 
-                                    case "name":
-                                        weekEvent.setName(event.getSummary());
-                                        weekEvent.setLocation(event.getLocation());
+                                        @Override
+                                        public void onCancelled(@NonNull DatabaseError databaseError) {
 
-                                    case "colorId":
-                                       if (event.getEtag() == null) {
-                                           weekEvent.setColor(Color.GRAY);
-                                       }
+                                        }
+                                    });
 
-                                        // Decided to forgo porting colors from google calendar events to save time
+                                    if (sendbirdUserData.get("user_type").equals("admin")) {
+                                        submissionButton.setVisibility(View.VISIBLE);
+                                    } else {
+                                        final String username = sendbirdUserData.get("user_name");
+                                        mDatabase.child("submissions").addValueEventListener(new ValueEventListener() {
+                                            @Override
+                                            public void onDataChange(@NonNull DataSnapshot dataSnapshot) {
+                                                Log.i("databaseval", "" + dataSnapshot.getValue());
+                                                listOfSubmissions.clear();
+                                                for (DataSnapshot mSnapshot : dataSnapshot.getChildren()) {
+                                                    Log.i("databaseval2", "" + mSnapshot.getValue());
+                                                    Event event = EventParser.parseSingleEvent(mSnapshot.getValue());
+                                                    if (event.getCreator().getDisplayName().equals(username)) {
+                                                        listOfSubmissions.add(event);
+                                                    }
+                                                }
+                                                mWeekView.notifyDatasetChanged();
+                                            }
+
+                                            @Override
+                                            public void onCancelled(@NonNull DatabaseError databaseError) {
+
+                                            }
+                                        });
+                                    }
+                                    progressBarCalendar.setVisibility(View.GONE);
+                                }
+                            });
+
+                    closeViewDialogueButton = (Button) viewEventDialogue.findViewById(R.id.finish_viewing_button);
+                    closeViewDialogueButton.setOnClickListener(new View.OnClickListener() {
+                        @Override
+                        public void onClick(View view) {
+                            viewEventDialogue.dismiss();
+                        }
+                    });
+
+                    WeekView.EventLongPressListener eventLongPressListener = new WeekView.EventLongPressListener() {
+                        @Override
+                        public void onEventLongPress(WeekViewEvent event, RectF eventRect) {
+                            // If the event color is gray, it is in the process of being created and does not yet exist in the google calendar.
+                            // because of this, we do not allow gray events to be edited.
+                            if (event.getColor() == Color.GRAY) return;
+                            // TODO: add validation to the case where event does not have a name. (event.getName() returns null reference)
+                            for (Event eventObj : events.getItems()) {
+                                if (event.getName().equals(eventObj.getSummary())) {
+                                    eventToView = eventObj;
+                                }
+                            }
+                            eventStart = event.getStartTime();
+                            DateFormat df = new SimpleDateFormat("h:mm");
+                            String sdt;
+                            if (eventToView.getEnd().getDate() != null) {
+                                sdt = df.format(new Date(eventToView.getEnd().getDate().getValue()));
+                            } else {
+                                sdt = df.format(new Date(eventToView.getEnd().getDateTime().getValue()));
+                            }
+
+                            if (sendbirdUserData.get("user_type").equals("admin")) {
+                                editEventName = (EditText) editEventDialogue.findViewById(R.id.event_name_edit);
+                                editEventLocation = (EditText) editEventDialogue.findViewById(R.id.event_location_edit);
+                                editEventDescription = (EditText) editEventDialogue.findViewById(R.id.event_description_edit);
+
+                                editEventName.setText(eventToView.getSummary());
+                                editEventLocation.setText(eventToView.getLocation());
+                                editEventDescription.setText(eventToView.getDescription());
+                                selectTimeButtonEdit.setText("Ending at " + sdt);
+
+                                editEventDialogue.show();
+                            } else {
+                                viewEventName = (TextView) viewEventDialogue.findViewById(R.id.event_name_view);
+                                viewEventLocation = (TextView) viewEventDialogue.findViewById(R.id.event_location_view);
+                                viewEventDescription = (TextView) viewEventDialogue.findViewById(R.id.event_description_view);
+
+                                viewEventName.setText(eventToView.getSummary());
+                                viewEventLocation.setText(eventToView.getLocation());
+                                viewEventDescription.setText(eventToView.getDescription());
+
+                                viewEventDialogue.show();
+                            }
+                        }
+                    };
+                    mWeekView.setEventLongPressListener(eventLongPressListener);
+
+                    WeekView.EmptyViewLongPressListener emptyViewLongPressListener = new WeekView.EmptyViewLongPressListener() {
+                        @Override
+                        public void onEmptyViewLongPress(java.util.Calendar time) {
+                            timePressed = time;
+                            createEventDialogue.show();
+                        }
+                    };
+                    mWeekView.setEmptyViewLongPressListener(emptyViewLongPressListener);
+
+                    /* TODO: assign event id to weekview id. its possible two events will have the same name. */
+                    MonthLoader.MonthChangeListener mMonthChangeListener = new MonthLoader.MonthChangeListener() {
+                        @Override
+                        public List<WeekViewEvent> onMonthChange(int newYear, int newMonth) {
+                            // Populate the week view with some events.
+                            List<WeekViewEvent> filteredEvents = new ArrayList<WeekViewEvent>();
+                            Event dummyEvent = new Event();
+                            if (events != null) {
+                                List<Event> listOfEvents = getEvents(newYear, newMonth);
+                                Class aClass = dummyEvent.getClass();
+                                for (Event event : listOfEvents) {
+                                    WeekViewEvent weekEvent = new WeekViewEvent();
+                                    for (Field field : aClass.getDeclaredFields()) {
+                                        field.setAccessible(true);
+                                        Log.i("field", "" + field.getName());
+                                        switch (field.getName()) {
+                                            case "end":
+                                                java.util.Calendar endCalendar = new GregorianCalendar();
+                                                String end;
+                                                if (event.getEnd().getDate() != null) {
+                                                    end = event.getEnd().getDate().toString();
+                                                } else {
+                                                    end = event.getEnd().getDateTime().toString();
+                                                }
+                                                SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+                                                Date date = new Date();
+                                                Long endMillis = 0L;
+                                                try {
+                                                    date = simpleDateFormat.parse(end);
+                                                    endMillis = date.getTime();
+                                                } catch (ParseException e) {
+                                                    Log.e("err", "" + e);
+                                                }
+                                                endCalendar.setTimeInMillis(endMillis);
+                                                weekEvent.setEndTime(endCalendar);
+
+                                            case "start":
+                                                java.util.Calendar startCalendar = new GregorianCalendar();
+                                                String start;
+                                                if (event.getStart().getDate() != null) {
+                                                    start = event.getStart().getDate().toString();
+                                                } else {
+                                                    start = event.getStart().getDateTime().toString();
+                                                }
+                                                SimpleDateFormat simpleDateFormatStart = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+                                                Date startDate = new Date();
+                                                Long startMillis = 0L;
+                                                try {
+                                                    startDate = simpleDateFormatStart.parse(start);
+                                                    startMillis = startDate.getTime();
+                                                } catch (ParseException e) {
+                                                    Log.e("err", "" + e);
+                                                }
+                                                startCalendar.setTimeInMillis(startMillis);
+                                                weekEvent.setStartTime(startCalendar);
+
+                                            case "id":
+                                                if (event.getEtag() != null) {
+                                                    weekEvent.setId(Long.parseLong(event.getEtag().replace("\"", "")));
+                                                } else {
+                                                    weekEvent.setId(new Random().nextInt(20000) + 1000);
+                                                }
+
+                                            case "name":
+                                                weekEvent.setName(event.getSummary());
+                                                weekEvent.setLocation(event.getLocation());
+
+                                            case "colorId":
+                                                if (event.getEtag() == null) {
+                                                    weekEvent.setColor(Color.GRAY);
+                                                }
+
+                                                // Decided to forgo porting colors from google calendar events to save time
 //                                        Log.i("color", "" + event.getColorId());
 //                                        if (event.getColorId() != null) {
 //                                            weekEvent.setColor(Color.parseColor(event.getColorId()));
 //                                        }
 
+                                        }
+                                    }
+                                    filteredEvents.add(weekEvent);
                                 }
+                                return filteredEvents;
+                            } else {
+                                return filteredEvents;
                             }
-                            filteredEvents.add(weekEvent);
                         }
-                    return filteredEvents;
-                } else {
-                    return filteredEvents;
+                    };
+                    mWeekView.setMonthChangeListener(mMonthChangeListener);
                 }
             }
-        };
-        mWeekView.setMonthChangeListener(mMonthChangeListener);
+        });
     }
 
     // UI handlers

--- a/app/src/main/java/com/eddierangel/southkern/android/main/LoginActivity.java
+++ b/app/src/main/java/com/eddierangel/southkern/android/main/LoginActivity.java
@@ -1,20 +1,22 @@
 package com.eddierangel.southkern.android.main;
 
 import android.app.Activity;
+import android.content.BroadcastReceiver;
+import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.design.widget.CoordinatorLayout;
 import android.support.design.widget.Snackbar;
-import android.support.design.widget.TextInputEditText;
 import android.support.v4.widget.ContentLoadingProgressBar;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
-import android.widget.ImageView;
 import android.widget.Toast;
 
 import com.firebase.ui.auth.AuthUI;
-import com.firebase.ui.auth.ui.idp.AuthMethodPickerActivity;
 import com.google.android.gms.tasks.Continuation;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.OnSuccessListener;
@@ -32,11 +34,8 @@ import com.sendbird.android.User;
 import com.eddierangel.southkern.android.R;
 import com.eddierangel.southkern.android.utils.PreferenceUtils;
 
-import org.json.JSONObject;
-
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 
@@ -45,6 +44,7 @@ public class LoginActivity extends AppCompatActivity {
     private CoordinatorLayout mLoginLayout;
     private HashMap<String, String> userData;
     private ContentLoadingProgressBar mProgressBar;
+    private BroadcastReceiver mConnReceiver;
 
     // Firebase instance variables
     private FirebaseAuth mFirebaseAuth;
@@ -52,8 +52,32 @@ public class LoginActivity extends AppCompatActivity {
     private FirebaseFunctions mFunctions;
     private static final int RC_SIGN_IN = 9;
 
+    private BroadcastReceiver networkChangeReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            Log.d("app","Network connectivity change");
 
-    /* function makes a call to the firebase function api to handle users with tokens. before we
+            Bundle bundle = intent.getExtras();
+
+            NetworkInfo networkInfo = (NetworkInfo) bundle.get("networkInfo");
+
+            if (networkInfo.isConnected() && mFirebaseAuth.getCurrentUser() != null) {
+                String userId = PreferenceUtils.getUserId(LoginActivity.this);
+                String sendbirdToken = PreferenceUtils.getSendbirdToken(LoginActivity.this);
+                String nickname;
+                if (userData != null) {
+                    nickname = userData.get("user_name");
+                } else {
+                    nickname = "resident";
+                }
+                connectToSendBird(userId, nickname, sendbirdToken);
+            }
+        }
+    };
+
+
+    /***
+     *  function makes a call to the firebase function api to handle users with tokens. before we
      * were using just the UID to connect with sendbird which was not secure. using firebase functions, we create
      * a secure endpoint that communicates with the sendbird platform API to provide a secure way to authorize users.
      * @param userID        user ID to register or log into sendbird service
@@ -105,7 +129,7 @@ public class LoginActivity extends AppCompatActivity {
                 if (user != null) {
                     // user is signed in
                     PreferenceUtils.setUserId(LoginActivity.this, user.getEmail());
-                    PreferenceUtils.setNickname(LoginActivity.this, "Guest");
+                    PreferenceUtils.setNickname(LoginActivity.this, "Resident");
 
                     // Show the loading indicator
                     showProgressBar(true);
@@ -142,12 +166,12 @@ public class LoginActivity extends AppCompatActivity {
                                                 Boolean firstLogin = (Boolean) task.getResult().get("firstLogin");
                                                 PreferenceUtils.setSendbirdToken(LoginActivity.this.getApplicationContext(), sendbirdToken);
                                                 if (firstLogin) {
-                                                    // It is the user's first time logging in -> show them UserCreation form
+                                                    // It is the users first time logging in -> show them UserCreation form
                                                     Intent intent = new Intent(LoginActivity.this, UserCreation.class);
                                                     startActivityForResult(intent, 1);
                                                 }
                                                 if (!firstLogin && task.getResult().get("nickname") != null) {
-                                                    // This isn't the user's first rodeo -> connect and show them main feed
+                                                    // This isn't the users first rodeo -> connect and show them main feed
                                                     String userNickname = (String) task.getResult().get("nickname");
                                                     connectToSendBird(userId, userNickname, sendbirdToken);
                                                 }
@@ -210,6 +234,7 @@ public class LoginActivity extends AppCompatActivity {
      * @param sendbirdToken The user's token that we will use to connect to sendbird securely.
      */
     private void connectToSendBird(final String userId, final String userNickname, final String sendbirdToken) {
+                showProgressBar(true);
 
         SendBird.connect(userId, sendbirdToken, new SendBird.ConnectHandler() {
             @Override
@@ -219,20 +244,19 @@ public class LoginActivity extends AppCompatActivity {
 
                 if (e != null) {
                     // Error!
-                    Log.i("connect", "" + e);
-                    Toast.makeText(
-                            LoginActivity.this, "" + e.getCode() + ": " + e.getMessage(),
-                            Toast.LENGTH_SHORT)
-                            .show();
+                    Log.e("login_error",  e.getCode() + " " + e);
 
                     // Show login failure snackbar
-                    showSnackbar("Login to SendBird failed");
+                    if (e.getCode() == 400302) {
+                        return; // Error message already propagated (access token is not valid)
+                    } else {
+                        showSnackbar("Login to SendBird failed. Reconnecting...");
+                    }
+
                     PreferenceUtils.setConnected(LoginActivity.this, false);
                     return;
                 }
-                Log.i("user_userdata", "" + userData);
                 if (userData != null) {
-                    Log.i("createmeta", "" + userData);
                     createUserMetaData(userData);
                 }
 
@@ -354,19 +378,20 @@ public class LoginActivity extends AppCompatActivity {
         }
     }
 
-    private void logOut() {
-        AuthUI.getInstance().signOut(this);
-    }
-
     @Override
     protected void onPause() {
         super.onPause();
+        unregisterReceiver(networkChangeReceiver);
+
         mFirebaseAuth.removeAuthStateListener(mAuthStateListener);
     }
 
     @Override
     protected void onResume() {
         super.onResume();
-       mFirebaseAuth.addAuthStateListener(mAuthStateListener);
+        IntentFilter intentFilter = new IntentFilter();
+        intentFilter.addAction(ConnectivityManager.CONNECTIVITY_ACTION);
+        registerReceiver(networkChangeReceiver, intentFilter);
+        mFirebaseAuth.addAuthStateListener(mAuthStateListener);
     }
 }

--- a/app/src/main/java/com/eddierangel/southkern/android/main/UserList.java
+++ b/app/src/main/java/com/eddierangel/southkern/android/main/UserList.java
@@ -27,7 +27,9 @@ import com.eddierangel.southkern.android.utils.AddressAdapter;
 import com.eddierangel.southkern.android.utils.AlertAdapter;
 import com.eddierangel.southkern.android.utils.EventAdapter;
 import com.eddierangel.southkern.android.utils.FeedAdapter;
+import com.eddierangel.southkern.android.utils.InternetCheck;
 import com.eddierangel.southkern.android.utils.PreferenceUtils;
+import com.eddierangel.southkern.android.utils.ReconnectionManager;
 import com.google.android.gms.tasks.Continuation;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
@@ -177,197 +179,209 @@ public class UserList extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        setContentView(R.layout.activity_address_book);
-        mToolbar = (Toolbar) findViewById(R.id.main_activity_toolbar);
-        setSupportActionBar(mToolbar);
-        getSupportActionBar().setDisplayShowTitleEnabled(false);
+        new InternetCheck(new InternetCheck.Consumer() {
+            @Override
+            public void accept(Boolean internet) {
+                if (!internet) {
+                    Intent intent = new Intent(UserList.this, ReconnectionManager.class);
+                    startActivity(intent);
+                    finish();
+                } else {
 
-        sortName = (ImageView) findViewById(R.id.sort_name);
-        sortOrganization = (ImageView) findViewById(R.id.sort_group);
-        backButton = (ImageButton) findViewById(R.id.menu_button_back);
-        organizationSearch = (EditText) findViewById(R.id.organization_search);
-        userListControls = (LinearLayout) findViewById(R.id.user_list_controls);
-        alertNavView = (NavigationView) findViewById(R.id.nav_view_alerts);
+                    setContentView(R.layout.activity_address_book);
+                    mToolbar = (Toolbar) findViewById(R.id.main_activity_toolbar);
+                    setSupportActionBar(mToolbar);
+                    getSupportActionBar().setDisplayShowTitleEnabled(false);
 
-        mFunctions = FirebaseFunctions.getInstance();
-        mDatabase = FirebaseDatabase.getInstance().getReference().getRoot();
+                    sortName = (ImageView) findViewById(R.id.sort_name);
+                    sortOrganization = (ImageView) findViewById(R.id.sort_group);
+                    backButton = (ImageButton) findViewById(R.id.menu_button_back);
+                    organizationSearch = (EditText) findViewById(R.id.organization_search);
+                    userListControls = (LinearLayout) findViewById(R.id.user_list_controls);
+                    alertNavView = (NavigationView) findViewById(R.id.nav_view_alerts);
+
+                    mFunctions = FirebaseFunctions.getInstance();
+                    mDatabase = FirebaseDatabase.getInstance().getReference().getRoot();
 
 
-        fetchUserList(PreferenceUtils.getFirebaseToken(this.getApplicationContext()))
-                .addOnCompleteListener(new OnCompleteListener<HashMap>() {
-                    @Override
-                    public void onComplete(@NonNull Task<HashMap> task) {
-                        if (!task.isSuccessful()) {
-                            Exception e = task.getException();
-                            if (e instanceof FirebaseFunctionsException) {
-                                FirebaseFunctionsException ffe = (FirebaseFunctionsException) e;
-                                FirebaseFunctionsException.Code code = ffe.getCode();
-                                Object details = ffe.getDetails();
-                            }
-                        }
-
-                        Log.i("usertest", "" + task.getResult().get("users"));
-                        // Success
-                        userList = (List<Object>) task.getResult().get("users"); // new ArrayList<Object>(((HashMap<Object, Object>) task.getResult().get("users")).values());
-                        originalUserList = userList;
-
-                        userListControls.setVisibility(View.VISIBLE);
-
-                        addressRecyclerView = (RecyclerView) findViewById(R.id.user_recycler_view);
-                        RecyclerView.LayoutManager mLayoutManager = new LinearLayoutManager(getApplicationContext());
-                        addressRecyclerView.setLayoutManager(mLayoutManager);
-                        addressRecyclerView.setItemAnimator(new DefaultItemAnimator());
-
-                        mAdapter = new AddressAdapter(userList, UserList.this.getApplicationContext());
-                        addressRecyclerView.setAdapter(mAdapter);
-
-                        ((AddressAdapter) mAdapter).setOnItemClickListener(new AddressAdapter.ClickListener() {
-                            @Override
-                            public void onItemClick(int position, View v) {
-                                HashMap user = (HashMap) userList.get(position);
-                                Intent intent = new Intent(UserList.this, ViewProfile.class);
-                                intent.putExtra("userId", (String)user.get("user_id"));
-                                startActivity(intent);
-                            }
-
-                            @Override
-                            public void onItemLongClick(int position, View v) {
-                                Log.d("onItemLongClick pos = ", "" + position);
-                            }
-
-                        });
-
-                        mDatabase.child("statusUpdates").addValueEventListener(new ValueEventListener() {
-                            @Override
-                            public void onDataChange(@NonNull DataSnapshot dataSnapshot) {
-
-                                for (DataSnapshot mSnapshot : dataSnapshot.getChildren()) {
-                                    HashMap statusObj = (HashMap) mSnapshot.getValue();
-                                    Event tempEvent = new Event();
-                                    tempEvent.setDescription((String) statusObj.get("text"));
-                                    tempEvent.setSummary("Status update");
-
-                                    EventDateTime dummyTime = new EventDateTime();
-                                    Long dateTime = Long.parseLong(statusObj.get("createdAt").toString());
-                                    DateTime createdAtTime = new DateTime(dateTime);
-                                    dummyTime.setDate(createdAtTime);
-                                    tempEvent.setStart(dummyTime);
-
-                                    if (!alertEvents.contains(tempEvent) && tempEvent.getStart().getDate().getValue() > (twoWeekTime / 2)) {
-                                        alertEvents.add(tempEvent);
+                    fetchUserList(PreferenceUtils.getFirebaseToken(UserList.this.getApplicationContext()))
+                            .addOnCompleteListener(new OnCompleteListener<HashMap>() {
+                                @Override
+                                public void onComplete(@NonNull Task<HashMap> task) {
+                                    if (!task.isSuccessful()) {
+                                        Exception e = task.getException();
+                                        if (e instanceof FirebaseFunctionsException) {
+                                            FirebaseFunctionsException ffe = (FirebaseFunctionsException) e;
+                                            FirebaseFunctionsException.Code code = ffe.getCode();
+                                            Object details = ffe.getDetails();
+                                        }
                                     }
 
+                                    Log.i("usertest", "" + task.getResult().get("users"));
+                                    // Success
+                                    userList = (List<Object>) task.getResult().get("users"); // new ArrayList<Object>(((HashMap<Object, Object>) task.getResult().get("users")).values());
+                                    originalUserList = userList;
+
+                                    userListControls.setVisibility(View.VISIBLE);
+
+                                    addressRecyclerView = (RecyclerView) findViewById(R.id.user_recycler_view);
+                                    RecyclerView.LayoutManager mLayoutManager = new LinearLayoutManager(getApplicationContext());
+                                    addressRecyclerView.setLayoutManager(mLayoutManager);
+                                    addressRecyclerView.setItemAnimator(new DefaultItemAnimator());
+
+                                    mAdapter = new AddressAdapter(userList, UserList.this.getApplicationContext());
+                                    addressRecyclerView.setAdapter(mAdapter);
+
+                                    ((AddressAdapter) mAdapter).setOnItemClickListener(new AddressAdapter.ClickListener() {
+                                        @Override
+                                        public void onItemClick(int position, View v) {
+                                            HashMap user = (HashMap) userList.get(position);
+                                            Intent intent = new Intent(UserList.this, ViewProfile.class);
+                                            intent.putExtra("userId", (String) user.get("user_id"));
+                                            startActivity(intent);
+                                        }
+
+                                        @Override
+                                        public void onItemLongClick(int position, View v) {
+                                            Log.d("onItemLongClick pos = ", "" + position);
+                                        }
+
+                                    });
+
+                                    mDatabase.child("statusUpdates").addValueEventListener(new ValueEventListener() {
+                                        @Override
+                                        public void onDataChange(@NonNull DataSnapshot dataSnapshot) {
+
+                                            for (DataSnapshot mSnapshot : dataSnapshot.getChildren()) {
+                                                HashMap statusObj = (HashMap) mSnapshot.getValue();
+                                                Event tempEvent = new Event();
+                                                tempEvent.setDescription((String) statusObj.get("text"));
+                                                tempEvent.setSummary("Status update");
+
+                                                EventDateTime dummyTime = new EventDateTime();
+                                                Long dateTime = Long.parseLong(statusObj.get("createdAt").toString());
+                                                DateTime createdAtTime = new DateTime(dateTime);
+                                                dummyTime.setDate(createdAtTime);
+                                                tempEvent.setStart(dummyTime);
+
+                                                if (!alertEvents.contains(tempEvent) && tempEvent.getStart().getDate().getValue() > (twoWeekTime / 2)) {
+                                                    alertEvents.add(tempEvent);
+                                                }
+
+                                            }
+
+                                            Collections.reverse(alertEvents);
+
+                                            mAdapter.notifyDataSetChanged();
+                                        }
+
+                                        @Override
+                                        public void onCancelled(@NonNull DatabaseError databaseError) {
+
+                                        }
+                                    });
                                 }
+                            });
 
-                                Collections.reverse(alertEvents);
+                    sortName.setOnClickListener(new View.OnClickListener() {
+                        @Override
+                        public void onClick(View view) {
+                            sortOrganization.setBackgroundColor(Color.TRANSPARENT);
+                            sortName.setBackgroundColor(Color.GRAY);
 
-                                mAdapter.notifyDataSetChanged();
+                            sortOrg = false;
+                            userList = originalUserList;
+                            if (sortAZ) {
+                                sortAZ = false;
+                                sortUserListNickname(userList);
+                            } else {
+                                sortAZ = true;
+                                sortName.setBackgroundColor(Color.TRANSPARENT);
+                                sortUserListNickname(userList);
+                                Collections.reverse(userList);
                             }
+                            mAdapter.notifyDataSetChanged();
+                        }
+                    });
 
-                            @Override
-                            public void onCancelled(@NonNull DatabaseError databaseError) {
+                    sortOrganization.setOnClickListener(new View.OnClickListener() {
+                        @Override
+                        public void onClick(View view) {
+                            sortName.setBackgroundColor(Color.TRANSPARENT);
+                            sortOrganization.setBackgroundColor(Color.GRAY);
 
+                            sortAZ = true;
+                            userList = originalUserList;
+                            if (sortOrg) {
+                                sortOrg = false;
+                                sortOrganization.setBackgroundColor(Color.TRANSPARENT);
+
+                                Collections.reverse(userList);
+                                sortUserListOrganization(userList);
+                            } else {
+                                sortOrg = true;
+                                sortOrganization.setBackgroundColor(Color.GRAY);
+                                sortUserListOrganization(userList);
+                                Collections.reverse(userList);
                             }
-                        });
-                    }
-                });
+                            mAdapter.notifyDataSetChanged();
+                        }
+                    });
 
-        sortName.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                sortOrganization.setBackgroundColor(Color.TRANSPARENT);
-                sortName.setBackgroundColor(Color.GRAY);
+                    organizationSearch.setOnClickListener(new View.OnClickListener() {
+                        @Override
+                        public void onClick(View view) {
 
-                sortOrg = false;
-                userList = originalUserList;
-                if (sortAZ) {
-                    sortAZ = false;
-                    sortUserListNickname(userList);
-                } else {
-                    sortAZ = true;
-                    sortName.setBackgroundColor(Color.TRANSPARENT);
-                    sortUserListNickname(userList);
-                    Collections.reverse(userList);
+                        }
+                    });
+
+                    organizationSearch.addTextChangedListener(new TextWatcher() {
+                        @Override
+                        public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+
+                        }
+
+                        @Override
+                        public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+
+                        }
+
+                        @Override
+                        public void afterTextChanged(Editable editable) {
+                            final String searchTerm = editable.toString().toLowerCase();
+                            userList = originalUserList;
+
+                            Collections.sort(userList, getMoveToFrontComparator(searchTerm));
+
+                            mAdapter.notifyDataSetChanged();
+                        }
+                    });
+
+                    backButton.setOnClickListener(new View.OnClickListener() {
+                        @Override
+                        public void onClick(View view) {
+                            Intent intent = new Intent(UserList.this, MainActivity.class);
+                            startActivity(intent);
+                        }
+                    });
+
+                    alertRecyclerView = (RecyclerView) findViewById(R.id.alert_recycler_view);
+                    RecyclerView.LayoutManager mLayoutAlertManager = new LinearLayoutManager(getApplicationContext());
+                    alertRecyclerView.setLayoutManager(mLayoutAlertManager);
+                    alertRecyclerView.setItemAnimator(new DefaultItemAnimator());
+                    alertAdapter = new AlertAdapter(alertEvents);
+                    alertRecyclerView.setAdapter(alertAdapter);
+
+                    viewAlertButton = (ImageButton) findViewById(R.id.alert_view_button);
+                    viewAlertButton.setOnClickListener(new View.OnClickListener() {
+                        @Override
+                        public void onClick(View view) {
+                            alertNavView.setVisibility(alertNavView.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
+                            viewAlertButton.setBackgroundColor(alertNavView.getVisibility() == View.VISIBLE ? Color.DKGRAY : Color.TRANSPARENT);
+
+                        }
+                    });
                 }
-                mAdapter.notifyDataSetChanged();
-            }
-        });
-
-        sortOrganization.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                sortName.setBackgroundColor(Color.TRANSPARENT);
-                sortOrganization.setBackgroundColor(Color.GRAY);
-
-                sortAZ = true;
-                userList = originalUserList;
-                if (sortOrg) {
-                    sortOrg = false;
-                    sortOrganization.setBackgroundColor(Color.TRANSPARENT);
-
-                    Collections.reverse(userList);
-                    sortUserListOrganization(userList);
-                } else {
-                    sortOrg = true;
-                    sortOrganization.setBackgroundColor(Color.GRAY);
-                    sortUserListOrganization(userList);
-                    Collections.reverse(userList);
-                }
-                mAdapter.notifyDataSetChanged();
-            }
-        });
-
-        organizationSearch.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-
-            }
-        });
-
-        organizationSearch.addTextChangedListener(new TextWatcher() {
-            @Override
-            public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
-
-            }
-
-            @Override
-            public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
-
-            }
-
-            @Override
-            public void afterTextChanged(Editable editable) {
-                final String searchTerm = editable.toString().toLowerCase();
-                userList = originalUserList;
-
-                Collections.sort(userList, getMoveToFrontComparator(searchTerm));
-
-                mAdapter.notifyDataSetChanged();
-            }
-        });
-
-        backButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                Intent intent = new Intent(UserList.this, MainActivity.class);
-                startActivity(intent);
-            }
-        });
-
-        alertRecyclerView = (RecyclerView) findViewById(R.id.alert_recycler_view);
-        RecyclerView.LayoutManager mLayoutAlertManager = new LinearLayoutManager(getApplicationContext());
-        alertRecyclerView.setLayoutManager(mLayoutAlertManager);
-        alertRecyclerView.setItemAnimator(new DefaultItemAnimator());
-        alertAdapter = new AlertAdapter(alertEvents);
-        alertRecyclerView.setAdapter(alertAdapter);
-
-        viewAlertButton = (ImageButton) findViewById(R.id.alert_view_button);
-        viewAlertButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                alertNavView.setVisibility(alertNavView.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
-                viewAlertButton.setBackgroundColor(alertNavView.getVisibility() == View.VISIBLE ? Color.DKGRAY : Color.TRANSPARENT);
-
             }
         });
     }

--- a/app/src/main/java/com/eddierangel/southkern/android/utils/FeedAdapter.java
+++ b/app/src/main/java/com/eddierangel/southkern/android/utils/FeedAdapter.java
@@ -69,12 +69,16 @@ public class FeedAdapter extends RecyclerView.Adapter<FeedAdapter.MyViewHolder> 
 
         @Override
         public void onClick(View v) {
-            clickListener.onItemClick(getAdapterPosition(), v);
+            if (clickListener != null) {
+                clickListener.onItemClick(getAdapterPosition(), v);
+            }
         }
 
         @Override
         public boolean onLongClick(View v) {
-            clickListener.onItemLongClick(getAdapterPosition(), v);
+            if (clickListener != null) {
+                clickListener.onItemLongClick(getAdapterPosition(), v);
+            }
             return false;
         }
     }

--- a/app/src/main/java/com/eddierangel/southkern/android/utils/InternetCheck.java
+++ b/app/src/main/java/com/eddierangel/southkern/android/utils/InternetCheck.java
@@ -1,0 +1,25 @@
+package com.eddierangel.southkern.android.utils;
+
+import android.os.AsyncTask;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+
+public class InternetCheck extends AsyncTask<Void,Void,Boolean> {
+
+    private Consumer mConsumer;
+    public  interface Consumer { void accept(Boolean internet); }
+
+    public  InternetCheck(Consumer consumer) { mConsumer = consumer; execute(); }
+
+    @Override protected Boolean doInBackground(Void... voids) { try {
+        Socket sock = new Socket();
+        sock.connect(new InetSocketAddress("8.8.8.8", 53), 1500);
+        sock.close();
+        return true;
+    } catch (IOException e) { return false; } }
+
+    @Override protected void onPostExecute(Boolean internet) { mConsumer.accept(internet); }
+}
+

--- a/app/src/main/java/com/eddierangel/southkern/android/utils/ReconnectionManager.java
+++ b/app/src/main/java/com/eddierangel/southkern/android/utils/ReconnectionManager.java
@@ -1,0 +1,66 @@
+package com.eddierangel.southkern.android.utils;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.design.widget.Snackbar;
+import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
+import android.widget.LinearLayout;
+
+import com.eddierangel.southkern.android.R;
+import com.eddierangel.southkern.android.main.LoginActivity;
+import com.eddierangel.southkern.android.main.MainActivity;
+
+import java.util.Timer;
+import java.util.TimerTask;
+
+public class ReconnectionManager extends AppCompatActivity {
+
+    private LinearLayout mLayout;
+    private Timer mTimer;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.reconnect_splash);
+
+        mLayout = (LinearLayout) findViewById(R.id.lost_connection_splash);
+
+        mTimer = new Timer();
+
+        mTimer.scheduleAtFixedRate(new TimerTask(){
+            @Override
+            public void run(){
+                new InternetCheck(new InternetCheck.Consumer() {
+                    @Override
+                    public void accept(Boolean internet) {
+                        // Once an internet connection has been reestablished, reroute to login so that the current sendbird user
+                        // can be reestablished.
+                        if (internet) {
+                            Intent intent = new Intent(ReconnectionManager.this, LoginActivity.class);
+                            startActivity(intent);
+                            finish();
+                        } else {
+                            showSnackbar("Reconnection failed. Trying again in 10 seconds.");
+                        }
+                    }
+                });
+            }
+        },0,10 * 1000); // 10 seconds
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+
+        mTimer.cancel();
+    }
+
+    // Displays a Snackbar from the bottom of the screen
+    private void showSnackbar(String text) {
+        Snackbar snackbar = Snackbar.make(mLayout, text, Snackbar.LENGTH_SHORT);
+
+        snackbar.show();
+    }
+}

--- a/app/src/main/res/layout/activity_calendar.xml
+++ b/app/src/main/res/layout/activity_calendar.xml
@@ -7,6 +7,11 @@
     android:layout_height="match_parent"
     android:background="#f2f3f4"
     tools:context="com.eddierangel.southkern.android.main.MainActivity">
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_gravity="center"
+        android:orientation="vertical">
 
 
     <android.support.design.widget.AppBarLayout
@@ -65,12 +70,6 @@
                 android:paddingRight="5dp" />
 
         </android.support.design.widget.NavigationView>
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_gravity="center"
-        android:orientation="vertical">
 
         <Button
             android:id="@+id/manage_submissions"

--- a/app/src/main/res/layout/reconnect_splash.xml
+++ b/app/src/main/res/layout/reconnect_splash.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout
+xmlns:android="http://schemas.android.com/apk/res/android"
+xmlns:tools="http://schemas.android.com/tools"
+xmlns:app="http://schemas.android.com/apk/res-auto"
+android:id="@+id/layout_login"
+android:layout_width="match_parent"
+android:layout_height="match_parent"
+android:gravity="center_horizontal"
+tools:context=".main.LoginActivity">
+
+
+<LinearLayout
+    android:id="@+id/lost_connection_splash"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center"
+    android:layout_marginLeft="@dimen/activity_horizontal_margin"
+    android:layout_marginRight="@dimen/activity_horizontal_margin"
+    android:orientation="vertical">
+
+    <ImageView
+        android:id="@+id/image_login_logo"
+        android:layout_width="320dp"
+        android:layout_height="233dp"
+        android:layout_gravity="center_horizontal"
+        android:src="@drawable/login_logo" />
+
+</LinearLayout>
+
+<android.support.v4.widget.ContentLoadingProgressBar
+    android:id="@+id/progress_bar_login"
+    style="?android:attr/progressBarStyleLarge"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="60dp"
+    android:layout_gravity="bottom|center" />
+
+<TextView
+    android:id="@+id/loading_text"
+    android:textSize="16sp"
+    android:layout_gravity="bottom|center"
+    android:textColor="#000000"
+    android:layout_marginBottom="20dp"
+    android:layout_height="wrap_content"
+    android:layout_width="wrap_content"
+    android:ellipsize="end"
+    android:maxLines="1"
+    android:text="@string/reconnecting" />
+
+
+</android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,18 +1,6 @@
 <resources>
     <string name="app_name">SouthKern</string>
 
-    <!-- Google Calendar -->
-    <string name="google_calendar_client_id">458185576063-lddeepif5cpdje1s1kdr14psid732gvr.apps.googleusercontent.com </string>
-    <string name="google_calendar_id">jfschmiechen@gmail.com</string>
-
-    <!-- Twitter -->
-    <string name="twitter_consumer_key">KBTW1JU8TXR2c8bDKNsplOYoN</string>
-    <string name="twitter_consumer_secret">f5Gg2xddiSz1NNzJZT8bJVNHBVDHA3SS9ky20UWJjIyIxrXtj9</string>
-
-    <!-- Facebook -->
-    <string name="facebook_app_id">296130564334095</string>
-    <string name="fb_login_protocol_scheme">fb296130564334095</string>
-
     <!-- all -->
     <string name="all_app_version">SouthKern v%1$s / SDK v%2$s</string>
 
@@ -102,6 +90,9 @@
     <string name="today">Today</string>
     <string name="community">What is going on in the community?</string>
     <string name="community_post">Post status update</string>
+
+    <!-- general -->
+    <string name="reconnecting">Internet connection lost. Reconnecting.</string>
 
 
 </resources>


### PR DESCRIPTION
The purpose of this pr is to add support for network drops in our application. Before, when we were logging in and the device lost connection to the internet the user would be faced with an infinite loading screen since the application never tried to reconnect resulting in a bad user experience. Also, if the user was looking at a view and lost connection then went to another activity it would cause a crash due to resources not being pulled from the internet.

Now, when the user logs in and their connection is dropped, they will reconnect as soon as an internet connection is available. When navigating to another view while there is no internet connection available will route the user to a new reconnection activity called ReconnectionManager which uses a web socket to quickly and efficiently test for an internet connection every 10 seconds. Upon an internet connection being available the user will be rerouted to the main feed where they can continue using the application.

I encountered an odd issue with the sendbird user remaining persistent through network drops so the user is routed to the login view. Since they are already authenticated with firebase their firebase token remains and they are reauthenticated with sendbird then sent to the main feed. Personally, I think it would be better to reroute the user to their original activity once a connection is reestablished but due to this consistency issue with sendbird I decided to save time and use this workaround. Further time could be invested to figure out this issue.

Other bugfixes:
    - Fixed issue with adapter not being initialized yet. Moved adapter initialization further up and updated recycler instead
    - Fixed calendar app bar from overlapping calendar header and submission management button. Now both should be viewable as either admins or community residents.
    - Fixed bug when tapping near an event caused a crash. Added a null check in the adapter to fix this.